### PR TITLE
Provide mroe explciit instructions to explain the second settings button

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -154,8 +154,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
 
     @Override
     public void onShowConfigTooltip() {
-        final String msg = "Press and hold config icons on black keys to exit.";
-        Toast toast = Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_LONG);
+        Toast toast = Toast.makeText(getApplicationContext(), R.string.config_tooltip, Toast.LENGTH_LONG);
         toast.show();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
         </big></b>
     </string>
     <string name="sound_set">Sound set</string>
+    <string name="config_tooltip">Hold the first gear icon, then press the second for options.</string>
 </resources>


### PR DESCRIPTION
### Change

Reworded:

> Press and hold config icons on black keys to exit.

To:

> Hold the first gear icon, then press the second for options.

*Note:* This wording assumes that #15 is merged (as it uses the word "gear"). But if you don't want to merge #15 then just let me know and I'll update this with more appropriate wording for the spanner icon.


### Details

Both my wife and I found it difficult to understand what was happening with the magical second settings button. In hindsight, it makes a lot of sense and is a very clever way to avoid accidental misclicks by curious children.

This extracts the text into a string to allow internationalisation, but also (hopefully) clarifies the behaviour.