### PR TITLE
Ensure at least 7 (non flat) keys are shown on small devices.

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -14,8 +14,8 @@ import java.util.Random;
 import java.util.Set;
 
 class AppConfigTrigger {
-    private static final int CONFIG_ICON_SIZE = 70;
-    private static final int CONFIG_ICON_SIZE_PRESSED = 50;
+    private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO = 0.5f;
+    private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED = 0.4f;
     private static final int CONFIG_TRIGGER_COUNT = 2;
     private static final Set<Integer> BLACK_KEYS = new HashSet<>(Arrays.asList(1, 3, 7, 9, 11, 15));
     private final AppCompatActivity activity;
@@ -93,13 +93,13 @@ class AppConfigTrigger {
     }
 
     void onPianoRedrawFinish(PianoCanvas piano, Canvas canvas) {
+        int pressedSize = (int) (piano.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED);
         for (Integer cfgKey : pressedConfigKeys) {
-            piano.draw_icon_on_black_key(canvas, icon, cfgKey,
-                    CONFIG_ICON_SIZE_PRESSED, CONFIG_ICON_SIZE_PRESSED);
+            piano.draw_icon_on_black_key(canvas, icon, cfgKey, pressedSize, pressedSize);
         }
 
-        piano.draw_icon_on_black_key(canvas, icon, nextKeyPress,
-                    CONFIG_ICON_SIZE, CONFIG_ICON_SIZE);
+        int normalSize = (int) (piano.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
+        piano.draw_icon_on_black_key(canvas, icon, nextKeyPress, normalSize, normalSize);
     }
 
     public interface AppConfigCallback {

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -10,8 +10,15 @@ import java.util.Arrays;
 
 class Piano {
     private static final double KEYS_FLAT_HEIGHT_RATIO = 0.55;
-    private static final int KEYS_WIDTH = 220;
-    private static final int KEYS_FLAT_WIDTH = 130;
+
+    /**
+     * Width of a flat key in relation to a regular key.
+     */
+    private static final double KEYS_FLAT_WIDTH_RATIO = 0.6;
+
+    private static final int MIN_NUMBER_OF_KEYS = 7;
+    private final int keys_width;
+    private final int keys_flat_width;
     private final int keys_height;
     private final int keys_flats_height;
     private final int keys_count;
@@ -23,14 +30,25 @@ class Piano {
         keys_height = screen_size_y;
         keys_flats_height = (int) (screen_size_y * KEYS_FLAT_HEIGHT_RATIO);
 
+        keys_width = Math.min(screen_size_x / MIN_NUMBER_OF_KEYS, 220);
+        keys_flat_width = (int) (keys_width * KEYS_FLAT_WIDTH_RATIO);
+
         // Round up for possible half-key display
-        final int big_keys = 1 + (screen_size_x / KEYS_WIDTH);
+        final int big_keys = 1 + (screen_size_x / keys_width);
         // Count flats too
         keys_count = (big_keys * 2) + 1;
 
         key_pressed = new boolean[keys_count];
         Arrays.fill(key_pressed, false);
         selectSoundset(context, soundset);
+    }
+
+    int get_keys_flat_width() {
+        return keys_flat_width;
+    }
+
+    int get_keys_width() {
+        return keys_width;
     }
 
     int get_keys_count() {
@@ -65,7 +83,7 @@ class Piano {
     }
 
     int pos_to_key_idx(float pos_x, float pos_y) {
-        final int big_key_idx = 2 * ((int) pos_x / KEYS_WIDTH);
+        final int big_key_idx = 2 * ((int) pos_x / keys_width);
         if (pos_y > keys_flats_height) return big_key_idx;
 
         // Check if press is inside rect of flat key
@@ -82,8 +100,8 @@ class Piano {
     }
 
     Key get_area_for_key(int key_idx) {
-        int x_i = key_idx / 2 * KEYS_WIDTH;
-        return new Key(x_i, x_i + KEYS_WIDTH, 0, keys_height);
+        int x_i = key_idx / 2 * keys_width;
+        return new Key(x_i, x_i + keys_width, 0, keys_height);
     }
 
     Key get_area_for_flat_key(int key_idx) {
@@ -93,9 +111,9 @@ class Piano {
             return new Key(0, 0, 0, 0);
         }
 
-        final int offset = KEYS_WIDTH - (KEYS_FLAT_WIDTH / 2);
-        int x_i = (key_idx / 2) * KEYS_WIDTH + offset;
-        return new Key(x_i, x_i + KEYS_FLAT_WIDTH, 0, keys_flats_height);
+        final int offset = keys_width - (keys_flat_width / 2);
+        int x_i = (key_idx / 2) * keys_width + offset;
+        return new Key(x_i, x_i + keys_flat_width, 0, keys_flats_height);
     }
 
     void selectSoundset(final Context context, String soundSetName) {

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -24,7 +24,9 @@ import java.util.Map;
 
 class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
 
-    private static final int BORDER_WIDTH = 24;
+    private static final float BEVEL_RATIO = 0.1f;
+
+    private final float bevelWidth;
 
     Piano piano;
     final AppConfigTrigger appConfigHandler;
@@ -67,6 +69,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         screen_size_y = screen_size.y;
         final String soundset = Preferences.selectedSoundSet(context);
         this.piano = new Piano(context, screen_size_x, screen_size_y, soundset);
+        this.bevelWidth = this.piano.get_keys_width() * BEVEL_RATIO;
         this.appConfigHandler = new AppConfigTrigger(ctx);
 
         Log.d("PianOli::DrawingCanvas", "Display is " + screen_size.x + "x" + screen_size.y +
@@ -142,8 +145,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         Path left = new Path();
         left.moveTo(r.left, r.top);
         left.lineTo(r.left, r.bottom);
-        left.lineTo(r.left + BORDER_WIDTH, r.bottom - BORDER_WIDTH);
-        left.lineTo(r.left + BORDER_WIDTH, r.top);
+        left.lineTo(r.left + bevelWidth, r.bottom - bevelWidth);
+        left.lineTo(r.left + bevelWidth, r.top);
         left.lineTo(r.left, r.top);
 
         p.setColor(ColorUtils.blendARGB(base, Color.BLACK, 0.3f));
@@ -162,8 +165,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         Path right = new Path();
         right.moveTo(r.right, r.top);
         right.lineTo(r.right, r.bottom);
-        right.lineTo(r.right - BORDER_WIDTH, r.bottom - BORDER_WIDTH);
-        right.lineTo(r.right - BORDER_WIDTH, r.top);
+        right.lineTo(r.right - bevelWidth, r.bottom - bevelWidth);
+        right.lineTo(r.right - bevelWidth, r.top);
         right.lineTo(r.right, r.top);
 
         p.setColor(ColorUtils.blendARGB(base, Color.WHITE, 0.2f));
@@ -177,8 +180,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         Path bottom = new Path();
         bottom.moveTo(r.left, r.bottom);
         bottom.lineTo(r.right, r.bottom);
-        bottom.lineTo(r.right - BORDER_WIDTH, r.bottom - BORDER_WIDTH);
-        bottom.lineTo(r.left + BORDER_WIDTH, r.bottom - BORDER_WIDTH);
+        bottom.lineTo(r.right - bevelWidth, r.bottom - bevelWidth);
+        bottom.lineTo(r.left + bevelWidth, r.bottom - bevelWidth);
         bottom.lineTo(r.left, r.bottom);
 
         p.setColor(ColorUtils.blendARGB(base, Color.BLACK, 0.1f));
@@ -192,7 +195,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
                                 final int icon_width, final int icon_height) {
         final Piano.Key key = piano.get_area_for_flat_key(key_idx);
         int icon_x = ((key.x_f - key.x_i) / 2) + key.x_i;
-        int icon_y = 30;
+        int icon_y = icon_height;
 
         Rect r = new Rect();
         r.left = icon_x - (icon_width / 2);


### PR DESCRIPTION
Changed from constant absolute key sizes. Add at least 7 keys depending on screen size.
If the screen can handle more, they will be the same size as before (220px). Everything
else is based on the resulting key size (e.g. flat key size, settings icon, width of
the bevel on the keys.

To simulate, I intentionally chose an extremely tiny emulator config of 240x432px (vs 1080x1920 as a comparison):

![emulator](https://user-images.githubusercontent.com/248565/104370329-ce420d00-5572-11eb-8fb0-d0a956b66eee.png) 
![emu-big](https://user-images.githubusercontent.com/248565/104370352-d69a4800-5572-11eb-9f55-2d9b903f1e91.png)

**Existing behaviour**

![broken](https://user-images.githubusercontent.com/248565/104370377-de59ec80-5572-11eb-86e3-a097aa77c532.png)

**Fixed behaviour**

![fixed2](https://user-images.githubusercontent.com/248565/104370403-e87beb00-5572-11eb-811e-6adfee04462d.png)

![fixed](https://user-images.githubusercontent.com/248565/104370448-fe89ab80-5572-11eb-840a-e2f29f74ddf2.png)

Fixes #18.