### PR TITLE
Minor changes to support Google Play publishing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 bin/
 gen/
 out/
+app/release/
+app/releaseGooglePlay/
 
 # Gradle files
 .gradle/
@@ -57,3 +59,4 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,23 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.nicobrailo.pianoli"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 15
         versionName "1.15"
     }
 
     buildTypes {
         release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+
+        releaseGooglePlay {
+            applicationIdSuffix = ".gplay"
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         <activity
             android:name=".MainActivity"
             android:screenOrientation="landscape"
-            android:configChanges="orientation|keyboardHidden">
+            android:configChanges="orientation|keyboardHidden"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Requires target API of 30 or higher, and the main activity must be
exported because it has an <intent-filter>. Also added a new
release flavour with a new application suffix, because somehow
somebody has uploaded the existing package name to GPlay even
though it isn't visible at that package name.