### PR TITLE
Correctly handle multi-finger move.

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -267,8 +267,6 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         int ptr_id = event.getPointerId(event.getActionIndex());
-        // final int ptr_idx = event.findPointerIndex(ptr_id);
-        // ptr_pos = event.getX(ptr_id), event.getY(ptr_id)
         int key_idx = piano.pos_to_key_idx(
                 event.getX(event.getActionIndex()),
                 event.getY(event.getActionIndex()));

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -266,10 +266,11 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        final int ptr_id = event.getPointerId(event.getActionIndex());
+        int ptr_id = event.getPointerId(event.getActionIndex());
         // final int ptr_idx = event.findPointerIndex(ptr_id);
         // ptr_pos = event.getX(ptr_id), event.getY(ptr_id)
-        final int key_idx = piano.pos_to_key_idx(event.getX(event.getActionIndex()),
+        int key_idx = piano.pos_to_key_idx(
+                event.getX(event.getActionIndex()),
                 event.getY(event.getActionIndex()));
 
         switch (event.getActionMasked()) {
@@ -290,19 +291,27 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
                 return true;
             }
             case MotionEvent.ACTION_MOVE: {
-                if (!touch_pointer_to_keys.containsKey(ptr_id)) {
-                    Log.e("PianOli::DrawingCanvas", "Touch-track error: Missed touch-up event");
-                    resetPianoState();
-                    return super.onTouchEvent(event);
-                }
+                // action_move is special, there is no *single* `getActionIndex`,
+                // as *multiple* pointers could have moved, so we must check *each* pointer.
+                // https://developer.android.com/develop/ui/views/touch-and-input/gestures/multi
+                for (int size = event.getPointerCount(), i = 0; i < size; i++) {
+                    ptr_id = event.getPointerId(i);  // cf precalc'd ptr_id above switch
+                    key_idx = piano.pos_to_key_idx(
+                            event.getX(i),
+                            event.getY(i));
 
-                // check if key changed
-                if (touch_pointer_to_keys.get(ptr_id) != key_idx) {
-                    Log.d("PianOli::DrawingCanvas", "Moved to another key");
-                    // Release key before storing new key_idx for new key down
-                    on_key_up(touch_pointer_to_keys.get(ptr_id));
-                    touch_pointer_to_keys.put(ptr_id, key_idx);
-                    on_key_down(key_idx);
+                    if (!touch_pointer_to_keys.containsKey(ptr_id)) {
+                        Log.e("PianOli::DrawingCanvas", "Touch-track error: Missed touch-up event");
+                        resetPianoState();
+                        return super.onTouchEvent(event);                    }
+                    // check if key changed
+                    if (touch_pointer_to_keys.get(ptr_id) != key_idx) {
+                        Log.d("PianOli::DrawingCanvas", "Moved to another key");
+                        // Release key before storing new key_idx for new key down
+                        on_key_up(touch_pointer_to_keys.get(ptr_id));
+                        touch_pointer_to_keys.put(ptr_id, key_idx);
+                        on_key_down(key_idx);
+                    }
                 }
 
                 return true;


### PR DESCRIPTION
So, I'm taking a stab at #40 as an MR.

Please be extra careful with this; I didn't even check if this compiles correctly, since I don't have an Android SDK environment set up.


fixes #40


Some interesting test-cases to test the new behaviour:
- "chord moves": touching keys 1+3+5, then sliding all three fingers to 2+4+6.
  - should play three notes, where before it only played 1->2
- "finger-switches": touching two *adjacent* keys with one finger each, (e.g 1+2)  
   then moving both fingers one to the left/right (2+3).
   - 2 remains activated, but since the touch-pointer doing the activating changed, it should play again
- the original test-case:
  -  touch key 1, then key 3 with a second finger,
  - move the second finger from key 3->4.  
     before: didn't play anything  
     now: should play note 4.
