### PR TITLE
Tooling Updates and polish

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
         <activity
             android:name=".SettingsActivity"
-            android:exported="false"
+            android:exported="true"
             android:label="@string/settings"
             android:parentActivityName=".MainActivity">
             <meta-data

--- a/app/src/main/java/com/nicobrailo/pianoli/AboutPreference.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AboutPreference.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.AttributeSet;
-import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
@@ -35,15 +35,10 @@ public class AboutPreference extends Preference {
     }
 
     @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
 
-        holder.itemView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                launchWebsite();
-            }
-        });
+        holder.itemView.setOnClickListener(view -> launchWebsite());
     }
 
     private void launchWebsite() {

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -19,7 +19,7 @@ class AppConfigTrigger {
     private static final int CONFIG_TRIGGER_COUNT = 2;
     private static final Set<Integer> BLACK_KEYS = new HashSet<>(Arrays.asList(1, 3, 7, 9, 11, 15));
     private final AppCompatActivity activity;
-    private Set<Integer> pressedConfigKeys = new HashSet<>();
+    private final Set<Integer> pressedConfigKeys = new HashSet<>();
     private Integer nextKeyPress;
     private AppConfigCallback cb = null;
     private boolean tooltip_shown = false;
@@ -55,7 +55,7 @@ class AppConfigTrigger {
     private void reset() {
         // Only do an actual reset if there was some state to reset, otherwise this will select a
         // new NextExpectedKey and move the icon around whenever the user presses a key
-        if (pressedConfigKeys.size() > 0) {
+        if (!pressedConfigKeys.isEmpty()) {
             nextKeyPress = getNextExpectedKey();
         }
 
@@ -88,7 +88,7 @@ class AppConfigTrigger {
             } else {
                 nextKeyPress = getNextExpectedKey();
             }
-        } else { 
+        } else {
             reset();
         }
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -5,7 +5,6 @@ import android.content.res.AssetManager;
 import android.media.SoundPool;
 import android.util.Log;
 
-import com.nicobrailo.pianoli.melodies.Melody;
 import com.nicobrailo.pianoli.melodies.MelodyPlayer;
 import com.nicobrailo.pianoli.melodies.MultipleSongsMelodyPlayer;
 
@@ -190,8 +189,8 @@ class Piano {
         if (key_idx == null) {
             Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
 
-            // 5 is designated as the special sound T.raw.no_note, so the app wont crash, but it wont
-            // play a noise either.
+            // 5 is designated as the special sound T.raw.no_note, so the app won't crash,
+            // but it won't play a noise either.
             return 5;
         }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -232,7 +232,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
 
     void resetPianoState() {
         // Something has gone wrong with the piano or canvas state, and our state is out of sync
-        // with the real state of the world (eg somehow we missed a touch down or up event).
+        // with the real state of the world (e.g. somehow we missed a touch down or up event).
         // Try to reset the state and hope the app survives.
         touch_pointer_to_keys.clear();
         piano.resetState();
@@ -273,7 +273,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
                 // as *multiple* pointers could have moved, so we must check *each* pointer.
                 // https://developer.android.com/develop/ui/views/touch-and-input/gestures/multi
                 for (int size = event.getPointerCount(), i = 0; i < size; i++) {
-                    ptr_id = event.getPointerId(i);  // cf precalc'd ptr_id above switch
+                    ptr_id = event.getPointerId(i);  // cf precalculated ptr_id above switch
                     key_idx = piano.pos_to_key_idx(
                             event.getX(i),
                             event.getY(i));

--- a/app/src/main/java/com/nicobrailo/pianoli/Preferences.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Preferences.java
@@ -5,7 +5,6 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.nicobrailo.pianoli.melodies.Melody;
-import com.nicobrailo.pianoli.melodies.SingleSongMelodyPlayer;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/com/nicobrailo/pianoli/SettingsFragment.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/SettingsFragment.java
@@ -29,7 +29,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     @Override
-    public void onCreatePreferences(Bundle savedzInstanceState, String rootKey) {
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.root_preferences, rootKey);
         loadSounds();
         loadMelodies();
@@ -61,7 +61,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         }
 
-        if (filtList.size() == 0) {
+        if (filtList.isEmpty()) {
             final String msg = "No sounds found, the keyboard won't work!";
             Toast toast = Toast.makeText(context, msg, Toast.LENGTH_LONG);
             toast.show();
@@ -88,8 +88,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             String[] melodyEntryValues = new String[Melody.all.length];
 
             // Ideally we'd also call setDefaultValue() here too and pass a Set<String>
-            // containing each melody. However, the system invokes the "persist default valeus"
-            // before we get here, and thus it never gets respected. Instead that is hardcoded
+            // containing each melody. However, the system invokes the "persist default values"
+            // before we get here, and thus it never gets respected. Instead, that is hardcoded
             // in a string-array and referenced directly in root_preferences.xml.
 
             for (int i = 0; i < Melody.all.length; i ++) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -21,6 +21,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.getLayout().buildDirectory
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@
 android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+# Checksum source: https://gradle.org/release-checksums/
+distributionSha256Sum=bb09982fdf52718e4c7b25023d10df6d35a5fff969860bdf5a5bd27a3ab27a9e
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1


### PR DESCRIPTION
Things to make development easier for ourselves
IntelliJ is a VERY helpful IDE, so might as well do a couple of things it suggests.

1. for personal developer convenience: allow launching the Android Emulator directly into the settings-activity.  
   This requires "exporting" the activity, which technically also makes it available to other apps to trigger.
   Since this activity doesn't inherently change state, I _think_ this is safe to expose.
    - I'm not an Android developer in any way, so please correct me if I overlooked any side effects of this change.
2. Gradle and the Android Gradle Plugin (AGP) have advanced, might as well use the latest versions.
    - Gradle 7.5 -> 8.3
    - AGP 7.4.2 -> 8.0.2 (the latest I could get working, 8.1.1 isn't compatible apparently?)
3. Build performance IDE suggestion: enable gradle config cache
    - also tested the "disable jetifier" suggestion, but my IDE concluded that some dependency apparently needs this.
4. While I was at it, do some small warning cleanups in the java code.
    - This includes English grammar and spelling in comments, because IntelliJ is awesome like that :smile: 