### PR TITLE
Translations, round 2: NL :netherlands:  polish, add DE :de: 

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="quit_app">Schließen</string>
+    <string name="settings">Einstellungen</string>
+
+    <!-- splash text at top of settings screen -->
+    <string name="some_info_about_this_app_title"><b><big><big>PianOli ist quell-offene Software!</big></big></b></string>
+    <string name="some_info_about_this_app">bei Vorschlägen, Wünschen oder Problemmeldungen <a
+            href="https://github.com/nicolasbrailo/PianOli">besuch unsere Webseite</a>.
+    </string>
+
+    <string name="config_tooltip">halte das erste Zahnrad gedrückt, tippe dann auf das zweite für Einstellungen.</string>
+
+    <!-- Sound set selection and instrument names -->
+    <string name="soundset">Klang</string>
+    <string name="soundset_guitar">Gitarre</string>
+    <string name="soundset_musicbox">Spieluhr</string>
+    <string name="soundset_piano">Piano</string>
+    <string name="soundset_sine">Sinuswelle</string>
+    <string name="soundset_vibraphone">Vibraphon</string>
+
+    <!-- Song player settings -->
+    <string name="pref_enable_melodies">Liederautomat</string>
+    <string name="pref_enable_melodies_summary">Tastenberührung spielt den nächsten Ton eines Liedes statt des
+        eigentlichen Tastentons.</string>
+    <string name="pref_selected_melodies">verfügbare Lieder</string>
+    <string name="pref_selected_melodies_summary">Lieder hinter einander gespielt</string>
+
+    <!-- keyboard colour themes -->
+    <string name="theme">Tastenfarben</string>
+    <string name="theme_black_and_white">schwarz-weiß</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,4 +10,5 @@
     <string name="soundset_vibraphone">Vibráfono</string>
     <string name="soundset_guitar">Guitarra</string>
     <string name="soundset_musicbox">Caja musical</string>
+    <string name="melody_insy_winsy_spider">Canción de la araña</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -12,6 +12,7 @@
 
     <!-- Sound set selection and instrument names -->
     <string name="soundset">Tipo de som</string>
+    <string name="soundset_musicbox">Caixa de música</string>
     <string name="soundset_piano">Piano</string>
     <string name="soundset_vibraphone">Vibrafone</string>
     <string name="soundset_guitar">Guitarra</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
 
     <!-- keyboard colour themes -->
-    <string name="theme">Theme</string>
+    <string name="theme">Key Colours</string>
     <string name="theme_black_and_white">Black and White</string>
     <string name="theme_boomwhacker" translatable="false">Boomwhacker</string>
     <string name="theme_pastel">Pastel</string>

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,0 +1,14 @@
+Ist Ihr Baby begierig auf Tablets oder Handys? Dann nutzen Sie diese App als
+Babyspiel und, wichtiger noch, um zu verhindern, dass unkoordinierte
+Babyberührungen unerwünschte Aktionen auslösen.
+
+Diese App zeigt einen kleines Piano mit dem das Baby Klänge erkunden kann.
+Außerdem blockiert es einfache Versuche, die App zu schließen.
+Die Zuruck-, Home- und App-Übersicht-Knöpfe sind gesperrt
+und Androids Schnell-Menü (ziehen von oben) ist nicht verfügbar.
+
+Das stellt sicher, dass ein Baby nicht versehentlich das Spiel schließt
+und anderswo im Gerät unerwünschte Aktionen auslöst.
+
+Erwachsene können die App entsperren, indem sie das Einstellungen-Symbol halten,
+und mit einem zweiten Finger das erscheinende Zweitsymbol antippen.

--- a/fastlane/metadata/android/de-DE/short_description.txt
+++ b/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,0 +1,1 @@
+Babyspiel um ihr Gerät vor unkoordinierte Babyberührungen zu schützen.

--- a/fastlane/metadata/android/de-DE/title.txt
+++ b/fastlane/metadata/android/de-DE/title.txt
@@ -1,0 +1,1 @@
+PianOli

--- a/fastlane/metadata/android/nl-NL/full_description.txt
+++ b/fastlane/metadata/android/nl-NL/full_description.txt
@@ -1,0 +1,16 @@
+Is jouw baby nieuwsgierig naar je tablet of telefoon? Gebruik deze app als
+baby-spelletje en, nog veel belangrijker, om te voorkomen dat de willekeurige
+aanrakingen van je baby iets uitvoeren wat je niet wilt.
+
+Deze app toont een klein pianotoetsenbord waarmee een baby geluiden
+kan verkennen op een mobiel apparaat. Tegelijkertijd dient het als
+schermbeveiliging die simpele pogingen om de app af te sluiten tegenhoudt.
+De Terug-, Home- en App-overzicht-knoppen worden geblokkeerd, net als het
+"Snelle instellingen" menu (sleep van boven)
+
+Dit zorgt ervoor dat een baby of klein kind niet zomaar uit het spelletje
+ontsnapt, en in de rest van je telefoon chaos aanricht.
+
+Volwassenen kunnen het scherm vrijgeven door het instellingen-icoon
+met één vinger vast te houden, en dan het verschijnende tweede icoontje
+aan te tikken met een tweede vinger.

--- a/fastlane/metadata/android/nl-NL/short_description.txt
+++ b/fastlane/metadata/android/nl-NL/short_description.txt
@@ -1,0 +1,1 @@
+Babyspelletje om je mobieltje te beschermen tegen gretige babyvingertjes.

--- a/fastlane/metadata/android/nl-NL/title.txt
+++ b/fastlane/metadata/android/nl-NL/title.txt
@@ -1,0 +1,1 @@
+PianOli


### PR DESCRIPTION
I've finally gotten my local native speaker to check my German translation, and boy-howdy, was it needed :sweat_smile: 

This branch 
- adds German :de:  translation
- adds Dutch :netherlands: translations for FastLane stuff, as pointed out in #61 
- sneaks in some finetuning to languages I don't actually speak, but seem reasonable by looking at Wikipedia article titles.