### PR TITLE
Melody refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
     compileSdkVersion 33
@@ -51,6 +52,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.preference:preference:1.2.0'
     implementation "androidx.annotation:annotation:1.6.0"
+
+    testImplementation "org.junit.jupiter:junit-jupiter:5.9.2"
 }
 
 // Not sure why this started happening all of a sudden, but the buidl was failing

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -10,6 +10,7 @@ import com.nicobrailo.pianoli.melodies.MultipleSongsMelodyPlayer;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Backing model / state of our virtual piano keyboard.
@@ -161,39 +162,48 @@ class Piano {
         KeySoundIdx = new int[28];
         final AssetManager am = context.getAssets();
         try {
-            KeySoundIdx[0] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n01.mp3"), 1);
-            KeySoundIdx[1] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n02.mp3"), 1);
-            KeySoundIdx[2] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n03.mp3"), 1);
-            KeySoundIdx[3] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n04.mp3"), 1);
-            KeySoundIdx[4] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n05.mp3"), 1);
-            KeySoundIdx[5] = KeySound.load(context, R.raw.no_note, 1);
-            KeySoundIdx[6] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n06.mp3"), 1);
-            KeySoundIdx[7] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n07.mp3"), 1);
-            KeySoundIdx[8] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n08.mp3"), 1);
-            KeySoundIdx[9] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n09.mp3"), 1);
-            KeySoundIdx[10] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n10.mp3"), 1);
-            KeySoundIdx[11] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n11.mp3"), 1);
-            KeySoundIdx[12] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n12.mp3"), 1);
-            KeySoundIdx[13] = KeySound.load(context, R.raw.no_note, 1);
+            int loadedNoNote = KeySound.load(context, R.raw.no_note, 1);
 
-            KeySoundIdx[14] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n13.mp3"), 1);
-            KeySoundIdx[15] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n14.mp3"), 1);
-            KeySoundIdx[16] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n15.mp3"), 1);
-            KeySoundIdx[17] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n16.mp3"), 1);
-            KeySoundIdx[18] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n17.mp3"), 1);
-            KeySoundIdx[19] = KeySound.load(context, R.raw.no_note, 1);
-            KeySoundIdx[20] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n18.mp3"), 1);
-            KeySoundIdx[21] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n19.mp3"), 1);
-            KeySoundIdx[22] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n20.mp3"), 1);
-            KeySoundIdx[23] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n21.mp3"), 1);
-            KeySoundIdx[24] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n22.mp3"), 1);
-            KeySoundIdx[25] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n23.mp3"), 1);
-            KeySoundIdx[26] = KeySound.load(am.openFd("sounds/" + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/n24.mp3"), 1);
-            KeySoundIdx[27] = KeySound.load(context, R.raw.no_note, 1);
+            KeySoundIdx[0]  = loadNoteFd(am, soundSetName, 1);
+            KeySoundIdx[1]  = loadNoteFd(am, soundSetName, 2);
+            KeySoundIdx[2]  = loadNoteFd(am, soundSetName, 3);
+            KeySoundIdx[3]  = loadNoteFd(am, soundSetName, 4);
+            KeySoundIdx[4]  = loadNoteFd(am, soundSetName, 5);
+            KeySoundIdx[5]  = loadedNoNote;
+            KeySoundIdx[6]  = loadNoteFd(am, soundSetName, 6);
+            KeySoundIdx[7]  = loadNoteFd(am, soundSetName, 7);
+            KeySoundIdx[8]  = loadNoteFd(am, soundSetName, 8);
+            KeySoundIdx[9]  = loadNoteFd(am, soundSetName, 9);
+            KeySoundIdx[10] = loadNoteFd(am, soundSetName, 10);
+            KeySoundIdx[11] = loadNoteFd(am, soundSetName, 11);
+            KeySoundIdx[12] = loadNoteFd(am, soundSetName, 12);
+            KeySoundIdx[13] = loadedNoNote;
+
+            KeySoundIdx[14] = loadNoteFd(am, soundSetName, 13);
+            KeySoundIdx[15] = loadNoteFd(am, soundSetName, 14);
+            KeySoundIdx[16] = loadNoteFd(am, soundSetName, 15);
+            KeySoundIdx[17] = loadNoteFd(am, soundSetName, 16);
+            KeySoundIdx[18] = loadNoteFd(am, soundSetName, 17);
+            KeySoundIdx[19] = loadedNoNote;
+            KeySoundIdx[20] = loadNoteFd(am, soundSetName, 18);
+            KeySoundIdx[21] = loadNoteFd(am, soundSetName, 19);
+            KeySoundIdx[22] = loadNoteFd(am, soundSetName, 20);
+            KeySoundIdx[23] = loadNoteFd(am, soundSetName, 21);
+            KeySoundIdx[24] = loadNoteFd(am, soundSetName, 22);
+            KeySoundIdx[25] = loadNoteFd(am, soundSetName, 23);
+            KeySoundIdx[26] = loadNoteFd(am, soundSetName, 24);
+            KeySoundIdx[27] = loadedNoNote;
         } catch (IOException e) {
             Log.d("PianOli::Piano", "Failed to load sounds");
             e.printStackTrace();
         }
+    }
+
+    private static int loadNoteFd(AssetManager am, String soundSetName, int noteNum) throws IOException {
+        return KeySound.load(am.openFd("sounds/"
+                + SettingsActivity.SOUNDSET_DIR_PREFIX + soundSetName + "/"
+                + String.format(Locale.ROOT, "n%02d.mp3", noteNum) // root locale OK for number-formatting.
+        ), 1);
     }
 
     private void play_sound(int key_idx) {

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -12,23 +12,43 @@ import com.nicobrailo.pianoli.melodies.NoteMapper;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * Backing model / state of our virtual piano keyboard.
+ *
+ * <p>
+ * Handles geometry, coordinate conversion and current state.
+ * </p>
+ *
+ * @see PianoCanvas
+ */
 class Piano {
+    /** Height of a flat key in relation to screen size. */
     private static final double KEYS_FLAT_HEIGHT_RATIO = 0.55;
 
-    /**
-     * Width of a flat key in relation to a regular key.
-     */
+    /** Width of a flat key in relation to a regular key. */
     private static final double KEYS_FLAT_WIDTH_RATIO = 0.6;
 
+    /**
+     * Floor limit, if screensize dictates less than this amount of keys, start shrinking key width,
+     * so we always display at least an octave.
+     */
     private static final int MIN_NUMBER_OF_KEYS = 7;
+
+
     private final int keys_width;
     private final int keys_flat_width;
     private final int keys_height;
     private final int keys_flats_height;
     private final int keys_count;
+
+    /** state tracker: which keys are <em>currently</em> pressed */
     private final boolean[] key_pressed;
+    /** handle to our android-provided sound mixer, that mixes multiple simultaneous tones */
     private static SoundPool KeySound = null;
+    /** Resource handles to the mp3 samples of our currently active soundset, one for each note */
     private int[] KeySoundIdx;
+
+    /** For song-auto-player, the state-tracker of where we are in our (selection of) melodie(s). */
     private MelodyPlayer melody = null;
 
     Piano(final Context context, int screen_size_x, int screen_size_y, final String soundset) {

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -7,11 +7,10 @@ import android.util.Log;
 
 import com.nicobrailo.pianoli.melodies.MelodyPlayer;
 import com.nicobrailo.pianoli.melodies.MultipleSongsMelodyPlayer;
+import com.nicobrailo.pianoli.melodies.NoteMapper;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 class Piano {
     private static final double KEYS_FLAT_HEIGHT_RATIO = 0.55;
@@ -131,74 +130,6 @@ class Piano {
         return new Key(x_i, x_i + keys_flat_width, 0, keys_flats_height);
     }
 
-    private static final Map<String, Integer> note_to_key_idx = new HashMap<>();
-
-    static {
-        note_to_key_idx.put("C1", 0);
-        note_to_key_idx.put("C#1", 1);
-        note_to_key_idx.put("Db1", 1);
-        note_to_key_idx.put("D♭1", 1);
-        note_to_key_idx.put("D1", 2);
-        note_to_key_idx.put("D#1", 3);
-        note_to_key_idx.put("Eb1", 3);
-        note_to_key_idx.put("E♭1", 3);
-        note_to_key_idx.put("E1", 4);
-
-        note_to_key_idx.put("F1", 6);
-        note_to_key_idx.put("F#1", 7);
-        note_to_key_idx.put("Gb1", 7);
-        note_to_key_idx.put("G♭1", 7);
-        note_to_key_idx.put("G1", 8);
-        note_to_key_idx.put("G#1", 9);
-        note_to_key_idx.put("Ab1", 9);
-        note_to_key_idx.put("A♭1", 9);
-        note_to_key_idx.put("A1", 10);
-        note_to_key_idx.put("A#1", 11);
-        note_to_key_idx.put("Bb1", 11);
-        note_to_key_idx.put("B♭1", 11);
-        note_to_key_idx.put("B1", 12);
-
-        note_to_key_idx.put("C2", 14);
-        note_to_key_idx.put("C#2", 15);
-        note_to_key_idx.put("Db2", 15);
-        note_to_key_idx.put("D♭2", 15);
-        note_to_key_idx.put("D2", 16);
-        note_to_key_idx.put("D#2", 17);
-        note_to_key_idx.put("Eb2", 17);
-        note_to_key_idx.put("E♭2", 17);
-        note_to_key_idx.put("E2", 18);
-
-        note_to_key_idx.put("F2", 20);
-        note_to_key_idx.put("F#2", 21);
-        note_to_key_idx.put("Gb2", 21);
-        note_to_key_idx.put("G♭2", 21);
-        note_to_key_idx.put("G2", 22);
-        note_to_key_idx.put("G#2", 23);
-        note_to_key_idx.put("Ab2", 23);
-        note_to_key_idx.put("A♭2", 23);
-        note_to_key_idx.put("A2", 24);
-        note_to_key_idx.put("A#2", 25);
-        note_to_key_idx.put("Bb2", 25);
-        note_to_key_idx.put("B♭2", 25);
-        note_to_key_idx.put("B2", 26);
-    }
-
-    int get_key_idx_from_note(String note) {
-
-        Integer key_idx = note_to_key_idx.get(note);
-        if (key_idx == null) {
-            Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
-
-            // 5 is designated as the special sound T.raw.no_note, so the app won't crash,
-            // but it won't play a noise either.
-            return 5;
-        }
-
-        return key_idx;
-    }
-
-
-
     void selectSoundset(final Context context, String soundSetName) {
         if (KeySound != null) {
             KeySound.release();
@@ -258,7 +189,7 @@ class Piano {
             }
 
             String note = this.melody.nextNote();
-            key_idx = get_key_idx_from_note(note);
+            key_idx = NoteMapper.get_key_idx_from_note(note);
         }
 
         KeySound.play(KeySoundIdx[key_idx], 1, 1, 1, 0, 1f);

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -7,7 +7,6 @@ import android.util.Log;
 
 import com.nicobrailo.pianoli.melodies.MelodyPlayer;
 import com.nicobrailo.pianoli.melodies.MultipleSongsMelodyPlayer;
-import com.nicobrailo.pianoli.melodies.NoteMapper;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -208,8 +207,7 @@ class Piano {
                 this.melody.reset();
             }
 
-            String note = this.melody.nextNote();
-            key_idx = NoteMapper.get_key_idx_from_note(note);
+            key_idx = this.melody.nextNote();
         }
 
         KeySound.play(KeySoundIdx[key_idx], 1, 1, 1, 0, 1f);

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -23,6 +23,9 @@ import androidx.core.graphics.ColorUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Renderer/View for our {@link Piano}.
+ */
 class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
 
     private static final float BEVEL_RATIO = 0.1f;
@@ -230,10 +233,12 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         redraw();
     }
 
+    /**
+     * Something has gone wrong with the piano or canvas state, and our state is out of sync
+     * with the real state of the world (e.g. somehow we missed a touch down or up event).
+     * Try to reset the state and hope the app survives.
+     */
     void resetPianoState() {
-        // Something has gone wrong with the piano or canvas state, and our state is out of sync
-        // with the real state of the world (e.g. somehow we missed a touch down or up event).
-        // Try to reset the state and hope the app survives.
         touch_pointer_to_keys.clear();
         piano.resetState();
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -1,7 +1,5 @@
 package com.nicobrailo.pianoli.melodies;
 
-import java.util.Locale;
-
 public class Melody {
 
     public static final Melody waltzing_matilda = fromString(
@@ -148,19 +146,20 @@ public class Melody {
      */
     static Melody fromString(String id, String plainTextNotes) {
         String[] notes = plainTextNotes.trim().split("\\s+");
+        int[] parsedNotes = new int[notes.length];
 
+        // Stream would be nicer, but we deliberately target ancient APIs,
+        // so our game works on old phones (which people are more likely to give to small children)
         for (int i = 0; i < notes.length; i++) {
-            if (!notes[i].matches(".*\\d$")) {
-                notes[i] = notes[i] + "1";
-            }
+            parsedNotes[i] = NoteMapper.get_key_idx_from_note(notes[i]);
         }
-        return new Melody(id, notes);
+        return new Melody(id, parsedNotes);
     }
 
     private final String id;
-    private final String[] notes;
+    private final int[] notes;
 
-    public Melody(String id, String[] notes) {
+    public Melody(String id, int[] notes) {
         this.id = id;
         this.notes = notes;
     }
@@ -169,7 +168,7 @@ public class Melody {
         return id;
     }
 
-    public String[] getNotes() {
+    public int[] getNotes() {
         return notes;
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -1,5 +1,6 @@
 package com.nicobrailo.pianoli.melodies;
 
+import android.util.Log;
 import com.nicobrailo.pianoli.song.ImALittleTeapot;
 import com.nicobrailo.pianoli.song.InsyWinsySpider;
 import com.nicobrailo.pianoli.song.TwinkleTwinkleLittleStar;
@@ -11,6 +12,9 @@ import com.nicobrailo.pianoli.song.WaltzingMatilda;
  * @see MelodyPlayer
  */
 public class Melody {
+    /** Log tag */
+    public static final String TAG = "MELODY";
+
     /**
      * All songs known to PianOli.
      *
@@ -45,7 +49,14 @@ public class Melody {
         // Stream would be nicer, but we deliberately target ancient APIs,
         // so our game works on old phones (which people are more likely to give to small children)
         for (int i = 0; i < notes.length; i++) {
-            parsedNotes[i] = NoteMapper.get_key_idx_from_note(notes[i]);
+            String note = notes[i];
+            int parsedNote = NoteMapper.get_key_idx_from_note(note);
+            parsedNotes[i] = parsedNote;
+
+            if (parsedNote == NoteMapper.NO_NOTE) {
+                // Log the parse-fail, while we still have all the context.
+                Log.w(TAG, String.format("%s: couldn't parse note '%s' at position %d", id, note, i));
+            }
         }
         return new Melody(id, parsedNotes);
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -1,138 +1,30 @@
 package com.nicobrailo.pianoli.melodies;
 
+import com.nicobrailo.pianoli.song.ImALittleTeapot;
+import com.nicobrailo.pianoli.song.InsyWinsySpider;
+import com.nicobrailo.pianoli.song.TwinkleTwinkleLittleStar;
+import com.nicobrailo.pianoli.song.WaltzingMatilda;
+
+/**
+ * Parsed representation of a children's song.
+ *
+ * @see MelodyPlayer
+ */
 public class Melody {
-
-    public static final Melody waltzing_matilda = fromString(
-            "waltzing_matilda",
-            "A A A A G G " +
-                    // Once a jolly swagman`
-
-                    "F A F D E F " +
-                    // camped by a billabong
-
-                    "C F A C2 C2 C2 " +
-                    // under the shade of a
-
-                    "C2 C2 C2 C2 " +
-                    // coolibah tree
-
-                    "F G A A A G G " +
-                    // And he sang as he watched and
-
-                    "F G A F D E F " +
-                    // waited till his Billy boiled
-
-                    "C F A C2 Bb A  " +
-                    // You'll come a waltzing ma-
-
-                    "G G G F " +
-                    // -tilda with me.
-
-                    "C2 C2 C2 C2 A " +
-                    // Waltzing Matilda,
-
-                    "F2 F2 E2 D2 C2 " +
-                    // Waltzing Matilda,
-
-                    "C2 C2 C2 D2 C2 C2 " +
-                    // You'll come a waltzing Mat-
-
-                    "C2 Bb A G F G " +
-                    // -tilda with me, And he
-
-                    "A A A G G " +
-                    // Sang as he watched and
-
-                    "F G A F D E F " +
-                    // waited till his Billy boiled,
-
-                    "C F A C2 Bb A " +
-                    // You'll come a waltzing Ma-
-
-                    "G G G F"
-            // -tilda with me.
-    );
-
-    public static final Melody im_a_little_teapot = fromString(
-            "im_a_little_teapot",
-            "C D E F G C2 " +
-                    // I’m a little teapot
-
-                    "A C2 G " +
-                    // Short and stout
-
-                    "F F F E E " +
-                    // Here is my handle
-
-                    "D D D C " +
-                    // Here is my spout
-
-                    "C D E F G C2 " +
-                    // When I get all steamed up
-
-                    "A C2 G " +
-                    // Hear me shout
-
-                    "C2 A G G " +
-                    // “Tip me over
-
-                    "F E D C "
-            // And pour me out!”
-    );
-
-    public static final Melody twinkle_twinkle_little_star = fromString(
-            "twinkle_twinkle_little_star",
-            "C C G G A A G " +
-                    // Twinkle, twinkle, little star
-
-                    "F F E E D D C " +
-                    // How I wonder what you are!
-
-                    "G G F F E E D " +
-                    // Up above the world so high,
-
-                    "G G F F E E D " +
-                    // Like a diamond in the sky...
-
-                    "C C G G A A G " +
-                    // Twinkle, twinkle, little star
-
-                    "F F E E D D C"
-            // How I wonder what you are!
-    );
-
-    public static final Melody insy_winsy_spider = fromString(
-            "insy_winsy_spider",
-            "G1 C2 C2 C2 D2 E2 E2 " +
-                    // "Insy-winsy spider...
-
-                    "E2 D2 C2 D2 E2 C2 " +
-                    // "... climbed up the water spout.
-
-                    "E2 E2 F2 G2 " +
-                    // Down came the rain...
-
-                    "G2 F2 E2 F2 G2 E2 " +
-                    // ... and washed the spider out.
-
-                    "C2 C2 D2 E2 " +
-                    // Out came the sun...
-
-                    "E2 D2 C2 D2 E2 C2 " +
-                    // ... and dried up all the rain.
-
-                    "G1 G1 C2 C2 C2 D2 E2 E2 " +
-                    // Insy-winsy spider...
-
-                    "E2 D2 C2 D2 E2 C2"
-            // ... climbed up the spout again.
-    );
-
+    /**
+     * All songs known to PianOli.
+     *
+     * <p>
+     * We need a central catalog, primarily so we know which options to present in the settings screen.
+     * It's not ideal to have this hardcoded, but the alternative (if we insist on song definitions in their own file)
+     * is classpath scanning, which is a can of worms I'm not willing to go into.
+     * </p>
+     */
     public static final Melody[] all = new Melody[]{
-            twinkle_twinkle_little_star,
-            insy_winsy_spider,
-            im_a_little_teapot,
-            waltzing_matilda
+            TwinkleTwinkleLittleStar.melody,
+            InsyWinsySpider.melody,
+            ImALittleTeapot.melody,
+            WaltzingMatilda.melody
     };
 
     /**
@@ -143,8 +35,10 @@ public class Melody {
      * <p>
      * Notes in the first octave can leave off the octave designation and it will be automatically
      * appended (i.e. "C" will become "C1"). This makes it simpler to write songs that fall within a single octave.
+     *
+     * @see NoteMapper
      */
-    static Melody fromString(String id, String plainTextNotes) {
+    public static Melody fromString(String id, String plainTextNotes) {
         String[] notes = plainTextNotes.trim().split("\\s+");
         int[] parsedNotes = new int[notes.length];
 

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/MelodyPlayer.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/MelodyPlayer.java
@@ -1,7 +1,7 @@
 package com.nicobrailo.pianoli.melodies;
 
 public interface MelodyPlayer {
-    String nextNote();
+    int nextNote();
     boolean hasNextNote();
     void reset();
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/MultipleSongsMelodyPlayer.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/MultipleSongsMelodyPlayer.java
@@ -35,7 +35,7 @@ public class MultipleSongsMelodyPlayer implements MelodyPlayer {
      * last melody is hit, go back to the first again.
      */
     @Override
-    public String nextNote() {
+    public int nextNote() {
         if (!songs.get(song_idx).hasNextNote()) {
             songs.get(song_idx).reset();
             song_idx = (song_idx + 1) % songs.size();
@@ -43,7 +43,6 @@ public class MultipleSongsMelodyPlayer implements MelodyPlayer {
         }
 
         return songs.get(song_idx).nextNote();
-
     }
 
     @Override

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
@@ -14,8 +14,13 @@ public class NoteMapper {
     public static final int NO_NOTE = 5;
 
     public static int get_key_idx_from_note(String note) {
-        if (note == null) {
+        if (note == null || note.isEmpty()) {
             return NO_NOTE;
+        }
+
+        char lastChar = note.charAt(note.length() - 1);
+        if (!Character.isDigit(lastChar)) {
+            note = note+"1";
         }
 
         switch (note) {

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
@@ -2,76 +2,98 @@ package com.nicobrailo.pianoli.melodies;
 
 import android.util.Log;
 
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Converts most common musical notations (C1, D#1, Eb1, G♭1) to soundset-key indexes.
  */
 public class NoteMapper {
-    private static final Map<String, Integer> note_to_key_idx = new HashMap<>();
 
-    static {
-        note_to_key_idx.put("C1", 0);
-        note_to_key_idx.put("C#1", 1);
-        note_to_key_idx.put("Db1", 1);
-        note_to_key_idx.put("D♭1", 1);
-        note_to_key_idx.put("D1", 2);
-        note_to_key_idx.put("D#1", 3);
-        note_to_key_idx.put("Eb1", 3);
-        note_to_key_idx.put("E♭1", 3);
-        note_to_key_idx.put("E1", 4);
-
-        note_to_key_idx.put("F1", 6);
-        note_to_key_idx.put("F#1", 7);
-        note_to_key_idx.put("Gb1", 7);
-        note_to_key_idx.put("G♭1", 7);
-        note_to_key_idx.put("G1", 8);
-        note_to_key_idx.put("G#1", 9);
-        note_to_key_idx.put("Ab1", 9);
-        note_to_key_idx.put("A♭1", 9);
-        note_to_key_idx.put("A1", 10);
-        note_to_key_idx.put("A#1", 11);
-        note_to_key_idx.put("Bb1", 11);
-        note_to_key_idx.put("B♭1", 11);
-        note_to_key_idx.put("B1", 12);
-
-        note_to_key_idx.put("C2", 14);
-        note_to_key_idx.put("C#2", 15);
-        note_to_key_idx.put("Db2", 15);
-        note_to_key_idx.put("D♭2", 15);
-        note_to_key_idx.put("D2", 16);
-        note_to_key_idx.put("D#2", 17);
-        note_to_key_idx.put("Eb2", 17);
-        note_to_key_idx.put("E♭2", 17);
-        note_to_key_idx.put("E2", 18);
-
-        note_to_key_idx.put("F2", 20);
-        note_to_key_idx.put("F#2", 21);
-        note_to_key_idx.put("Gb2", 21);
-        note_to_key_idx.put("G♭2", 21);
-        note_to_key_idx.put("G2", 22);
-        note_to_key_idx.put("G#2", 23);
-        note_to_key_idx.put("Ab2", 23);
-        note_to_key_idx.put("A♭2", 23);
-        note_to_key_idx.put("A2", 24);
-        note_to_key_idx.put("A#2", 25);
-        note_to_key_idx.put("Bb2", 25);
-        note_to_key_idx.put("B♭2", 25);
-        note_to_key_idx.put("B2", 26);
-    }
+    /**
+     * 5 is designated as the special sound T.raw.no_note, so the app won't crash, but it won't play a noise either.
+     */
+    public static final int NO_NOTE = 5;
 
     public static int get_key_idx_from_note(String note) {
-
-        Integer key_idx = NoteMapper.note_to_key_idx.get(note);
-        if (key_idx == null) {
-            Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
-
-            // 5 is designated as the special sound T.raw.no_note, so the app won't crash,
-            // but it won't play a noise either.
-            return 5;
+        if (note == null) {
+            return NO_NOTE;
         }
 
-        return key_idx;
+        switch (note) {
+            // Octave 1
+            case "C1":
+                return 0;
+            case "C#1":
+            case "Db1":
+            case "D♭1":
+                return 1;
+            case "D1":
+                return 2;
+            case "D#1":
+            case "Eb1":
+            case "E♭1":
+                return 3;
+            case "E1":
+                return 4;
+            case "F1":
+                return 6;
+            case "F#1":
+            case "Gb1":
+            case "G♭1":
+                return 7;
+            case "G1":
+                return 8;
+            case "G#1":
+            case "Ab1":
+            case "A♭1":
+                return 9;
+            case "A1":
+                return 10;
+            case "A#1":
+            case "Bb1":
+            case "B♭1":
+                return 11;
+            case "B1":
+                return 12;
+
+            // Octave 2
+            case "C2":
+                return 14;
+            case "C#2":
+            case "Db2":
+            case "D♭2":
+                return 15;
+            case "D2":
+                return 16;
+            case "D#2":
+            case "Eb2":
+            case "E♭2":
+                return 17;
+            case "E2":
+                return 18;
+            case "F2":
+                return 20;
+            case "F#2":
+            case "Gb2":
+            case "G♭2":
+                return 21;
+            case "G2":
+                return 22;
+            case "G#2":
+            case "Ab2":
+            case "A♭2":
+                return 23;
+            case "A2":
+                return 24;
+            case "A#2":
+            case "Bb2":
+            case "B♭2":
+                return 25;
+            case "B2":
+                return 26;
+
+            default:
+                Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
+                return NO_NOTE;
+        }
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
@@ -1,8 +1,5 @@
 package com.nicobrailo.pianoli.melodies;
 
-import android.util.Log;
-
-
 /**
  * Converts most common musical notations (C1, D#1, Eb1, G♭1) to soundset-key indexes.
  */
@@ -97,7 +94,6 @@ public class NoteMapper {
                 return 26;
 
             default:
-                Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
                 return NO_NOTE;
         }
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
@@ -1,0 +1,77 @@
+package com.nicobrailo.pianoli.melodies;
+
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Converts most common musical notations (C1, D#1, Eb1, G♭1) to soundset-key indexes.
+ */
+public class NoteMapper {
+    private static final Map<String, Integer> note_to_key_idx = new HashMap<>();
+
+    static {
+        note_to_key_idx.put("C1", 0);
+        note_to_key_idx.put("C#1", 1);
+        note_to_key_idx.put("Db1", 1);
+        note_to_key_idx.put("D♭1", 1);
+        note_to_key_idx.put("D1", 2);
+        note_to_key_idx.put("D#1", 3);
+        note_to_key_idx.put("Eb1", 3);
+        note_to_key_idx.put("E♭1", 3);
+        note_to_key_idx.put("E1", 4);
+
+        note_to_key_idx.put("F1", 6);
+        note_to_key_idx.put("F#1", 7);
+        note_to_key_idx.put("Gb1", 7);
+        note_to_key_idx.put("G♭1", 7);
+        note_to_key_idx.put("G1", 8);
+        note_to_key_idx.put("G#1", 9);
+        note_to_key_idx.put("Ab1", 9);
+        note_to_key_idx.put("A♭1", 9);
+        note_to_key_idx.put("A1", 10);
+        note_to_key_idx.put("A#1", 11);
+        note_to_key_idx.put("Bb1", 11);
+        note_to_key_idx.put("B♭1", 11);
+        note_to_key_idx.put("B1", 12);
+
+        note_to_key_idx.put("C2", 14);
+        note_to_key_idx.put("C#2", 15);
+        note_to_key_idx.put("Db2", 15);
+        note_to_key_idx.put("D♭2", 15);
+        note_to_key_idx.put("D2", 16);
+        note_to_key_idx.put("D#2", 17);
+        note_to_key_idx.put("Eb2", 17);
+        note_to_key_idx.put("E♭2", 17);
+        note_to_key_idx.put("E2", 18);
+
+        note_to_key_idx.put("F2", 20);
+        note_to_key_idx.put("F#2", 21);
+        note_to_key_idx.put("Gb2", 21);
+        note_to_key_idx.put("G♭2", 21);
+        note_to_key_idx.put("G2", 22);
+        note_to_key_idx.put("G#2", 23);
+        note_to_key_idx.put("Ab2", 23);
+        note_to_key_idx.put("A♭2", 23);
+        note_to_key_idx.put("A2", 24);
+        note_to_key_idx.put("A#2", 25);
+        note_to_key_idx.put("Bb2", 25);
+        note_to_key_idx.put("B♭2", 25);
+        note_to_key_idx.put("B2", 26);
+    }
+
+    public static int get_key_idx_from_note(String note) {
+
+        Integer key_idx = NoteMapper.note_to_key_idx.get(note);
+        if (key_idx == null) {
+            Log.w("PianOli::Piano", "Could not find a key corresponding to the note \"" + note + "\".");
+
+            // 5 is designated as the special sound T.raw.no_note, so the app won't crash,
+            // but it won't play a noise either.
+            return 5;
+        }
+
+        return key_idx;
+    }
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/SingleSongMelodyPlayer.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/SingleSongMelodyPlayer.java
@@ -1,23 +1,22 @@
 package com.nicobrailo.pianoli.melodies;
 
-import java.util.Locale;
 import java.util.NoSuchElementException;
 
 public class SingleSongMelodyPlayer implements MelodyPlayer {
 
     private int melody_idx = 0;
-    private Melody melody;
+    private final Melody melody;
 
     SingleSongMelodyPlayer(Melody melody) {
         this.melody = melody;
     }
 
     @Override
-    public String nextNote() {
+    public int nextNote() {
         if (!hasNextNote()) {
             throw new NoSuchElementException();
         }
-        String note = melody.getNotes()[melody_idx];
+        int note = melody.getNotes()[melody_idx];
         melody_idx ++;
         return note;
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/song/ImALittleTeapot.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/song/ImALittleTeapot.java
@@ -1,0 +1,32 @@
+package com.nicobrailo.pianoli.song;
+
+import com.nicobrailo.pianoli.melodies.Melody;
+
+public class ImALittleTeapot {
+    public static final Melody melody = Melody.fromString(
+            "im_a_little_teapot",
+            "C D E F G C2 " +
+                    // I’m a little teapot
+
+                    "A C2 G " +
+                    // Short and stout
+
+                    "F F F E E " +
+                    // Here is my handle
+
+                    "D D D C " +
+                    // Here is my spout
+
+                    "C D E F G C2 " +
+                    // When I get all steamed up
+
+                    "A C2 G " +
+                    // Hear me shout
+
+                    "C2 A G G " +
+                    // “Tip me over
+
+                    "F E D C "
+            // And pour me out!”
+    );
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/song/InsyWinsySpider.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/song/InsyWinsySpider.java
@@ -1,0 +1,32 @@
+package com.nicobrailo.pianoli.song;
+
+import com.nicobrailo.pianoli.melodies.Melody;
+
+public class InsyWinsySpider {
+    public static final Melody melody = Melody.fromString(
+            "insy_winsy_spider",
+            "G1 C2 C2 C2 D2 E2 E2 " +
+                    // "Insy-winsy spider...
+
+                    "E2 D2 C2 D2 E2 C2 " +
+                    // "... climbed up the water spout.
+
+                    "E2 E2 F2 G2 " +
+                    // Down came the rain...
+
+                    "G2 F2 E2 F2 G2 E2 " +
+                    // ... and washed the spider out.
+
+                    "C2 C2 D2 E2 " +
+                    // Out came the sun...
+
+                    "E2 D2 C2 D2 E2 C2 " +
+                    // ... and dried up all the rain.
+
+                    "G1 G1 C2 C2 C2 D2 E2 E2 " +
+                    // Insy-winsy spider...
+
+                    "E2 D2 C2 D2 E2 C2"
+            // ... climbed up the spout again.
+    );
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/song/TwinkleTwinkleLittleStar.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/song/TwinkleTwinkleLittleStar.java
@@ -1,0 +1,26 @@
+package com.nicobrailo.pianoli.song;
+
+import com.nicobrailo.pianoli.melodies.Melody;
+
+public class TwinkleTwinkleLittleStar {
+    public static final Melody melody = Melody.fromString(
+            "twinkle_twinkle_little_star",
+            "C C G G A A G " +
+                    // Twinkle, twinkle, little star
+
+                    "F F E E D D C " +
+                    // How I wonder what you are!
+
+                    "G G F F E E D " +
+                    // Up above the world so high,
+
+                    "G G F F E E D " +
+                    // Like a diamond in the sky...
+
+                    "C C G G A A G " +
+                    // Twinkle, twinkle, little star
+
+                    "F F E E D D C"
+            // How I wonder what you are!
+    );
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/song/WaltzingMatilda.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/song/WaltzingMatilda.java
@@ -1,0 +1,56 @@
+package com.nicobrailo.pianoli.song;
+
+import com.nicobrailo.pianoli.melodies.Melody;
+
+public class WaltzingMatilda {
+    public static Melody melody = Melody.fromString(
+            "waltzing_matilda",
+            "A A A A G G " +
+                    // Once a jolly swagman`
+
+                    "F A F D E F " +
+                    // camped by a billabong
+
+                    "C F A C2 C2 C2 " +
+                    // under the shade of a
+
+                    "C2 C2 C2 C2 " +
+                    // coolibah tree
+
+                    "F G A A A G G " +
+                    // And he sang as he watched and
+
+                    "F G A F D E F " +
+                    // waited till his Billy boiled
+
+                    "C F A C2 Bb A  " +
+                    // You'll come a waltzing ma-
+
+                    "G G G F " +
+                    // -tilda with me.
+
+                    "C2 C2 C2 C2 A " +
+                    // Waltzing Matilda,
+
+                    "F2 F2 E2 D2 C2 " +
+                    // Waltzing Matilda,
+
+                    "C2 C2 C2 D2 C2 C2 " +
+                    // You'll come a waltzing Mat-
+
+                    "C2 Bb A G F G " +
+                    // -tilda with me, And he
+
+                    "A A A G G " +
+                    // Sang as he watched and
+
+                    "F G A F D E F " +
+                    // waited till his Billy boiled,
+
+                    "C F A C2 Bb A " +
+                    // You'll come a waltzing Ma-
+
+                    "G G G F"
+            // -tilda with me.
+    );
+}

--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -1,0 +1,40 @@
+package android.util;
+
+/**
+ * Extremely hacky, dumb test-double of Android-Logging, which we use throughout the app
+ *
+ * <p>
+ * When test-compiling, this will shadow the default (not-mocked-exception-throwing) implementation
+ * provided by the Android Gradle Plugin.<br>
+ * This is a low-tech way of avoiding a full-featured mocking dependency like Powermock or Mockito.
+ * </p>
+ * <p>
+ * See also: Android Developer Guide: <a href="https://developer.android.com/training/testing/local-tests#mocking-dependencies">Build local unit tests</a><br>
+ * Thank you <a href="https://stackoverflow.com/a/46793567">StackOverflow answer 46793567</a>.
+ * </p>
+ *
+ * @noinspection unused
+ */
+public class Log {
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+
+    // add other methods if required...
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
@@ -1,0 +1,31 @@
+package com.nicobrailo.pianoli.melodies;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MelodyTest {
+
+    /** JUnit5 arguments-adapter for {@link Melody} content */
+    private static Stream<Arguments> enumerateAllMelodies() {
+        return Arrays.stream(Melody.all)
+                .map(m -> Arguments.of(m.getId(), m.getNotes()));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}") // name: avoid default note-array in testname, only songId
+    @MethodSource("enumerateAllMelodies")
+    public void allSongsParsable(String songId, String[] notes) {
+            int noteIndex = 0;
+            for (String note: notes) {
+                assertNotEquals(NoteMapper.NO_NOTE, NoteMapper.get_key_idx_from_note(note),
+                        String.format("Can't parse song %s, note '%s' at note position %d not recognised",
+                                songId, note, noteIndex));
+                noteIndex++;
+        }
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
@@ -19,12 +19,12 @@ class MelodyTest {
 
     @ParameterizedTest(name = "[{index}] {0}") // name: avoid default note-array in testname, only songId
     @MethodSource("enumerateAllMelodies")
-    public void allSongsParsable(String songId, String[] notes) {
+    public void allSongsParsable(String songId, int[] notes) {
             int noteIndex = 0;
-            for (String note: notes) {
-                assertNotEquals(NoteMapper.NO_NOTE, NoteMapper.get_key_idx_from_note(note),
-                        String.format("Can't parse song %s, note '%s' at note position %d not recognised",
-                                songId, note, noteIndex));
+            for (int note: notes) {
+                assertNotEquals(NoteMapper.NO_NOTE, note,
+                        String.format("Can't parse song %s, note at position %d not recognised",
+                                songId, noteIndex));
                 noteIndex++;
         }
     }

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
@@ -2,6 +2,7 @@ package com.nicobrailo.pianoli.melodies;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static com.nicobrailo.pianoli.melodies.NoteMapper.get_key_idx_from_note;
@@ -23,5 +24,20 @@ class NoteMapperTest {
     public void fancySynonyms(String note) {
         assertEquals(1, get_key_idx_from_note(note),
                 "all synonyms for the same note should work, including fancy symbols");
+    }
+
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "fooooooo"})
+    public void noNoteFallback(String notANote) {
+        assertEquals(5, get_key_idx_from_note(notANote),
+                "non-existing notes should fall back to the not-a-note special value");
+    }
+
+    @Test
+    public void nullSafe() {
+        assertEquals(5, get_key_idx_from_note(null),
+                "Notemapper should gracefully handle null");
     }
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
@@ -1,0 +1,27 @@
+package com.nicobrailo.pianoli.melodies;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.nicobrailo.pianoli.melodies.NoteMapper.get_key_idx_from_note;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NoteMapperTest {
+
+    @Test
+    public void noteRangeLimits() {
+        assertEquals(0, get_key_idx_from_note("C1"),
+                "lowest parsable note should be parsed");
+        assertEquals(26, get_key_idx_from_note("B2"),
+                "lowest parsable note should be parsed");
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"C#1", "Db1", "D♭1"})
+    public void fancySynonyms(String note) {
+        assertEquals(1, get_key_idx_from_note(note),
+                "all synonyms for the same note should work, including fancy symbols");
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
@@ -40,4 +40,18 @@ class NoteMapperTest {
         assertEquals(5, get_key_idx_from_note(null),
                 "Notemapper should gracefully handle null");
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "C",                //  0, first note of octave
+            "C#", "Db", "D♭",   //  1
+            "A",                // 10
+            "A#", "Bb","B♭",    // 11
+            "B"                 // 12, last note of octave
+    })
+    public void firstOctaveAutoCompletion(String shortNote) {
+        String fullNote = shortNote + "1";
+        assertEquals(get_key_idx_from_note(fullNote), get_key_idx_from_note(shortNote),
+                "NoteMapper should autocomplete ommited first octave");
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.9.3.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
I'm practicing my refactoring-fu, and have been wanting to try out JUnit5 for ages.  
The result is this branch :smile: 

Please let me know what you think!

It:
- moves song definitions to dedicated files.
  - I think this makes contribution of future songs more accessible, as the "template" for a new song becomes disentangled from app-logic.
- extracts all the `String` -> `key_idx` conversion done in `Piano` to a dedicated `NoteMapper`
  - as well as the octave-autocompletion that was hidden in `Melody`
- adds JUnit5 so that I could actually write tests for this
  - Google only supports JUnit4 natively in their gradle plugin, so I needed to add a community plugin:  
    https://github.com/mannodermaus/android-junit5  
    I'm not sure how acceptable that is? 
- Convert `Melody` to store already-parsed `key_idx`, rather than String-notes.
  - This means notes are only bulk-parsed once during app-initialisation, rather than one-note-at-a-time
     (and repeatedly) as we hit keys.
- Another test to check that I didn't break song-parsing: iterates over all available songs to check they don't contain `NO_NOTE`(==5)
  - ![image](https://github.com/nicolasbrailo/PianOli/assets/7068025/65597248-2885-40d4-bce3-f75df210cb0a)
- Some polish and JavaDoc that I added as I worked my way through understanding `Piano`


