### PR TITLE
Attempt to fix common crash with pinned mode when not in foreground.

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -70,12 +70,6 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
         lock_app();
     }
 
-    public void quitApp() {
-        unlock_app();
-        this.startActivity(new Intent(this, MainActivity.class));
-        moveTaskToBack(true);
-    }
-
     private static final int REQUEST_CONFIG = 1;
 
     @Override
@@ -87,22 +81,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
         // child accidentally getting to the settings screen.
         unlock_app();
 
-        startActivityForResult(new Intent(this, SettingsActivity.class), REQUEST_CONFIG);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-
-        if (requestCode == REQUEST_CONFIG) {
-            if (resultCode == SettingsActivity.RESULT_QUIT) {
-                quitApp();
-            }
-
-            // Don't need to lock the app if the user just hit the "Up" button in the action bar here again,
-            // because onResume would have already been called.
-        }
+        startActivity(new Intent(this, SettingsActivity.class));
     }
 
     @Override

--- a/app/src/main/java/com/nicobrailo/pianoli/SettingsActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/SettingsActivity.java
@@ -11,7 +11,6 @@ import androidx.appcompat.app.AppCompatActivity;
 public class SettingsActivity extends AppCompatActivity {
 
     public static final String SOUNDSET_DIR_PREFIX = "soundset_";
-    public static final int RESULT_QUIT = 1;
 
     public SettingsActivity() {
         // empty ctor may be required for fragments
@@ -37,8 +36,11 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     private void onQuit() {
-        setResult(RESULT_QUIT);
-        finish();
+        // Really don't want to go back to the main activity after quiting, so a normal
+        // finish() is no good (https://stackoverflow.com/questions/17719634/how-to-exit-an-android-app-programmatically).
+        // If we return to the main activity, it will prompt to lock the screen again, as if
+        // it was just launched.
+        finishAffinity();
     }
 
     @Override


### PR DESCRIPTION
When quitting, we accidentally returned to the start and launched the main app again, instead of quitting.

Not sure if it actually fixes #65, but perhaps it has a shot at addressing it. At the least, it fixes a weird behaviour that is worth fixing:

[weird-lock-behaviour.webm](https://github.com/nicolasbrailo/PianOli/assets/248565/c5735e45-bf5a-4c4d-a0b9-bf064d00ff08)
