### PR TITLE
More fun with JUnit 5

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/Key.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Key.java
@@ -1,0 +1,32 @@
+package com.nicobrailo.pianoli;
+
+/**
+ * Area taken up by a Piano key.
+ *
+ * <p>
+ * for both X and Y, <code>i <= f</code> (you can have keys with zero width/height, e.g. for the non-existing flats.
+ * </p>
+ */
+class Key {
+    /** null-object for keys: zero-area, so cannot be touched. (It's Hammer Time!) */
+    public static final Key CANT_TOUCH_THIS = new Key(0, 0, 0, 0);
+
+    /** Height of a flat key in relation to a regular key. */
+    public static final double FLAT_HEIGHT_RATIO = 0.55;
+    /** Width of a flat key in relation to a regular key. */
+    public static final double FLAT_WIDTH_RATIO = 0.6;
+
+    int x_i, x_f, y_i, y_f;
+
+    Key(int x_i, int x_f, int y_i, int y_f) {
+        this.x_i = x_i;
+        this.x_f = x_f;
+        this.y_i = y_i;
+        this.y_f = y_f;
+    }
+
+    boolean contains(float pos_x, float pos_y) {
+        return (pos_x > x_i && pos_x < x_f) &&
+                (pos_y > y_i && pos_y < y_f);
+    }
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -44,7 +44,7 @@ class Piano {
     /** handle to our android-provided sound mixer, that mixes multiple simultaneous tones */
     private static SoundPool KeySound = null;
     /** Resource handles to the mp3 samples of our currently active soundset, one for each note */
-    private int[] KeySoundIdx;
+    private int[] KeySoundIdx = new int[0]; // HACK: init empty to prevent NPE in tests
 
     /** For song-auto-player, the state-tracker of where we are in our (selection of) melodie(s). */
     private MelodyPlayer melody = null;
@@ -108,7 +108,7 @@ class Piano {
 
     boolean is_key_pressed(int key_idx) {
         if (key_idx < 0 || key_idx >= key_pressed.length) {
-            Log.d("PianOli::Piano", "This shouldn't happen: Sound out of range, key" + key_idx);
+            Log.d("PianOli::Piano", "This shouldn't happen: isKeyPressed out of range, key" + key_idx);
             return false;
         }
 
@@ -117,7 +117,7 @@ class Piano {
 
     void on_key_down(int key_idx) {
         if (key_idx < 0 || key_idx >= key_pressed.length) {
-            Log.d("PianOli::Piano", "This shouldn't happen: Sound out of range, key" + key_idx);
+            Log.d("PianOli::Piano", "This shouldn't happen: Key-Down out of range, key" + key_idx);
             return;
         }
         key_pressed[key_idx] = true;
@@ -126,7 +126,7 @@ class Piano {
 
     void on_key_up(int key_idx) {
         if (key_idx < 0 || key_idx >= key_pressed.length) {
-            Log.d("PianOli::Piano", "This shouldn't happen: Sound out of range, key" + key_idx);
+            Log.d("PianOli::Piano", "This shouldn't happen: Key-Up out of range, key" + key_idx);
             return;
         }
 
@@ -167,6 +167,8 @@ class Piano {
         return new Key(x_i, x_i + keys_flat_width, 0, keys_flats_height);
     }
 
+    // Developer note: Sound-playing deals with android-resources, which makes me think
+    //     it would be better of in PianoCanvas instead (so Piano becomes pure "geometry")
     void selectSoundset(final Context context, String soundSetName) {
         if (KeySound != null) {
             KeySound.release();

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -22,17 +22,15 @@ import java.util.Locale;
  * @see PianoCanvas
  */
 class Piano {
-    /** Height of a flat key in relation to screen size. */
-    private static final double KEYS_FLAT_HEIGHT_RATIO = 0.55;
-
-    /** Width of a flat key in relation to a regular key. */
-    private static final double KEYS_FLAT_WIDTH_RATIO = 0.6;
-
     /**
      * Floor limit, if screensize dictates less than this amount of keys, start shrinking key width,
      * so we always display at least an octave.
+     *
+     * @see #KEY_PREFERRED_WIDTH
      */
     private static final int MIN_NUMBER_OF_KEYS = 7;
+    /** Preferred width (device independent pixels) of a key, but see also {@link #MIN_NUMBER_OF_KEYS} */
+    public static final int KEY_PREFERRED_WIDTH = 220;
 
 
     private final int keys_width;
@@ -53,18 +51,19 @@ class Piano {
 
     Piano(final Context context, int screen_size_x, int screen_size_y, final String soundset) {
         keys_height = screen_size_y;
-        keys_flats_height = (int) (screen_size_y * KEYS_FLAT_HEIGHT_RATIO);
+        keys_flats_height = (int) (screen_size_y * Key.FLAT_HEIGHT_RATIO);
 
-        keys_width = Math.min(screen_size_x / MIN_NUMBER_OF_KEYS, 220);
-        keys_flat_width = (int) (keys_width * KEYS_FLAT_WIDTH_RATIO);
+        keys_width = Math.min(screen_size_x / MIN_NUMBER_OF_KEYS, KEY_PREFERRED_WIDTH);
+        keys_flat_width = (int) (keys_width * Key.FLAT_WIDTH_RATIO);
 
         // Round up for possible half-key display
         final int big_keys = 1 + (screen_size_x / keys_width);
         // Count flats too
-        keys_count = (big_keys * 2) + 1;
+        keys_count = (big_keys * 2) + 1; // *2 because ALL big keys get a matching flat-key, though for some its 0x0 pixels.
 
         key_pressed = new boolean[keys_count];
         Arrays.fill(key_pressed, false);
+
         selectSoundset(context, soundset);
 
         if (Preferences.areMelodiesEnabled(context)) {
@@ -142,7 +141,7 @@ class Piano {
         final int octave_idx = (key_idx / 2) % 7;
         if (octave_idx == 2 || octave_idx == 6) {
             // Keys without flat get a null-area
-            return new Key(0, 0, 0, 0);
+            return Key.CANT_TOUCH_THIS;
         }
 
         final int offset = keys_width - (keys_flat_width / 2);
@@ -221,21 +220,5 @@ class Piano {
         }
 
         KeySound.play(KeySoundIdx[key_idx], 1, 1, 1, 0, 1f);
-    }
-
-    static class Key {
-        int x_i, x_f, y_i, y_f;
-
-        Key(int x_i, int x_f, int y_i, int y_f) {
-            this.x_i = x_i;
-            this.x_f = x_f;
-            this.y_i = y_i;
-            this.y_f = y_f;
-        }
-
-        boolean contains(float pos_x, float pos_y) {
-            return (pos_x > x_i && pos_x < x_f) &&
-                    (pos_y > y_i && pos_y < y_f);
-        }
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -28,7 +28,7 @@ class Piano {
      *
      * @see #KEY_PREFERRED_WIDTH
      */
-    private static final int MIN_NUMBER_OF_KEYS = 7;
+    public static final int MIN_NUMBER_OF_KEYS = 7;
     /** Preferred width (device independent pixels) of a key, but see also {@link #MIN_NUMBER_OF_KEYS} */
     public static final int KEY_PREFERRED_WIDTH = 220;
 
@@ -49,7 +49,19 @@ class Piano {
     /** For song-auto-player, the state-tracker of where we are in our (selection of) melodie(s). */
     private MelodyPlayer melody = null;
 
-    Piano(final Context context, int screen_size_x, int screen_size_y, final String soundset) {
+    /**
+     * Construct a partially initialised (geometry only) Piano model.
+     *
+     * <p>
+     * Resource- and Preference-depedendent init is deferred to {@link #init(Context, String)}, for better testability.
+     * </p>
+     *
+     * @param screen_size_x the long dimension of the screen (keys are side-by-side along this axis)
+     * @param screen_size_y the short dimension of the screen.
+     *
+     * @see #init(Context, String)
+     */
+    Piano(int screen_size_x, int screen_size_y) {
         keys_height = screen_size_y;
         keys_flats_height = (int) (screen_size_y * Key.FLAT_HEIGHT_RATIO);
 
@@ -59,17 +71,23 @@ class Piano {
         // Round up for possible half-key display
         final int big_keys = 1 + (screen_size_x / keys_width);
         // Count flats too
-        keys_count = (big_keys * 2) + 1; // *2 because ALL big keys get a matching flat-key, though for some its 0x0 pixels.
+        // *2: Because ALL big keys get a matching flat-key, though for some its 0x0 pixels.
+        // +1: not sure about this... The *2 already ensures a (partial) flat-key on the (partial) big-key.
+        keys_count = (big_keys * 2) + 1;
 
         key_pressed = new boolean[keys_count];
         Arrays.fill(key_pressed, false);
+    }
 
+    Piano init(final Context context, final String soundset) {
         selectSoundset(context, soundset);
 
         if (Preferences.areMelodiesEnabled(context)) {
             this.melody = new MultipleSongsMelodyPlayer(Preferences.selectedMelodies(context));
             this.melody.reset();
         }
+
+        return this;
     }
 
     int get_keys_flat_width() {

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -65,7 +65,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         screen_size_x = screen_size.x;
         screen_size_y = screen_size.y;
         final String soundset = Preferences.selectedSoundSet(context);
-        this.piano = new Piano(context, screen_size_x, screen_size_y, soundset);
+        this.piano = new Piano(screen_size_x, screen_size_y)
+                .init(context, soundset);
         this.bevelWidth = this.piano.get_keys_width() * BEVEL_RATIO;
         this.appConfigHandler = new AppConfigTrigger(ctx);
 
@@ -74,7 +75,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
     }
 
     public void selectSoundset(final Context context, final String selected_soundset) {
-        this.piano = new Piano(context, screen_size_x, screen_size_y, selected_soundset);
+        this.piano = new Piano(screen_size_x, screen_size_y)
+                .init(context, selected_soundset);
     }
 
     public void setConfigRequestCallback(AppConfigTrigger.AppConfigCallback cb) {

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -109,7 +109,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
         appConfigHandler.onPianoRedrawFinish(this, canvas);
     }
 
-    void draw_key(final Canvas canvas, final Piano.Key rect, final Paint p) {
+    void draw_key(final Canvas canvas, final Key rect, final Paint p) {
         // Draw the main (solid) background of the key.
 
         Rect r = new Rect();
@@ -186,7 +186,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback {
      */
     void draw_icon_on_black_key(final Canvas canvas, final Drawable icon, Integer key_idx,
                                 final int icon_width, final int icon_height) {
-        final Piano.Key key = piano.get_area_for_flat_key(key_idx);
+        final Key key = piano.get_area_for_flat_key(key_idx);
         int icon_x = ((key.x_f - key.x_i) / 2) + key.x_i;
         int icon_y = icon_height;
 

--- a/app/src/test/java/com/nicobrailo/pianoli/KeyContainsTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/KeyContainsTest.java
@@ -1,0 +1,82 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KeyContainsTest {
+
+    private Key key;
+
+    @BeforeEach
+    void initKey() {
+        key = new Key(0, 10, 0, 10);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.00001,0.000001",
+            "0.00001,9.99999",
+            "9.99999,0.00001",
+            "9.99999,9.99999",
+            "5,5"})
+    void insideCounts(float x, float y) {
+        assertTrue(key.contains(x, y), "inside points should be contained");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "-0.00001,-0.000001",
+            "0,10.00001", "10.00001,0",
+            "10.00001,10.00001",
+            "1000,1000",
+            "-1000,-1000"})
+    void outside(float x, float y) {
+        assertFalse(key.contains(x, y), "outside points shouldn't be contained");
+    }
+
+    /**
+     * Like in Tennis or in Volleybal, "line is out"
+     */
+    @ParameterizedTest
+    @CsvSource({"0,0", "0,10", "10,0", "10,10", "5,0", "0,5", "10,5", "5,10"})
+    void edgesShouldntCount(float x, float y) {
+        assertFalse(key.contains(x,y));
+    }
+
+    /**
+     * Note that, since edges don't count on <em>all</em> sides, there is an (infinitely thin) area <em>between</em>
+     * adjacent keys that belongs to neither key.
+     *
+     * @see #edgesShouldntCount(float, float)
+     */
+    @Test
+    void noMansLand() {
+        int border = 10;
+        Key left = new Key(0, border, -5, 5);
+        Key right = new Key(border, 2*border, -5, 5);
+
+        assertFalse(left.contains(border, 0));
+        assertFalse(right.contains(border, 0));
+
+        Key top = new Key(-5, 5, border, 2*border);
+        Key bottom = new Key(-5, 5, 0, border);
+
+        assertFalse(top.contains(0, border));
+        assertFalse(bottom.contains(0, border ));
+    }
+
+    /**
+     * Zero-area key is used as null-object for the non-existing flat-keys.
+     */
+    @Test
+    void pointKeyShouldBeUntouchable() {
+        assertFalse(Key.CANT_TOUCH_THIS.contains( 0, 0));
+        assertFalse(Key.CANT_TOUCH_THIS.contains(-0, 0)); // negative-zero: fun with floats!
+        assertFalse(Key.CANT_TOUCH_THIS.contains( 0,-0));
+        assertFalse(Key.CANT_TOUCH_THIS.contains(-0,-0));
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/PianoTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/PianoTest.java
@@ -1,0 +1,61 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+class PianoTest {
+    private static Piano piano;
+
+    @BeforeAll
+    static void setup() {
+        piano = new Piano(500, 80);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints={-1, 18, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000, +1000})
+    void OutOfBoundsNeverPressed(int invalidIdx) {
+        assertFalse(piano.is_key_pressed(invalidIdx));
+    }
+
+
+    static Stream<Arguments> allKeyIndexes() {
+        return IntStream.range(0, piano.get_keys_count())
+                .mapToObj(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allKeyIndexes")
+    void keyPressLifecycle(int i) {
+        assertFalse(piano.is_key_pressed(i));
+
+        piano.on_key_down(i);
+        assertTrue(piano.is_key_pressed(i));
+
+        piano.on_key_up(i);
+        assertFalse(piano.is_key_pressed(i));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allKeyIndexes")
+    void resetState(int i) {
+        // prepare, set keyPressed to true
+        // only assume it works, actual test-fails covered by #keyPressLifecycle
+        // if an "assumption" fails, the test counts as "@Ignored".
+        assumeFalse(piano.is_key_pressed(i));
+        piano.on_key_down(i);
+        assumeTrue(piano.is_key_pressed(i));
+
+        piano.resetState();
+
+        assertFalse(piano.is_key_pressed(i));
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/PianoUndersizedScreensizeTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/PianoUndersizedScreensizeTest.java
@@ -1,0 +1,40 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Does our Piano function properly on tiny screens?
+ *
+ * <p>
+ * Goal is to always show at least an octave.
+ * </p>
+ *
+ * @see Piano#KEY_PREFERRED_WIDTH
+ * @see Piano#MIN_NUMBER_OF_KEYS
+ */
+class PianoUndersizedScreensizeTest {
+    private Piano tinyPiano;
+
+    @BeforeEach
+    void setup() {
+        int tinyWidth = 74; // should end up with 10 pixels per big key, plus a bit for a partial first-key-of-next-octave
+        tinyPiano = new Piano(tinyWidth, 10);
+    }
+
+    @Test
+    void keyWidths() {
+        assertEquals(10, tinyPiano.get_keys_width());
+        assertEquals(6, tinyPiano.get_keys_flat_width());
+    }
+
+    @Test
+    void alwaysShowAtLeastAnOctave() {
+        // 17: 7 big keys for first octave, rounded up to +1 partial key at right edge of screen.
+        //     each big key has a matching flat, for another +8
+        //     flat keys are rounded up too (that sounds like it's not needed?) for another +1
+        assertEquals(17, tinyPiano.get_keys_count());
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
@@ -1,5 +1,6 @@
 package com.nicobrailo.pianoli.melodies;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,5 +28,18 @@ class MelodyTest {
                                 songId, noteIndex));
                 noteIndex++;
         }
+    }
+
+    @Test
+    void garbageParsesAsNoNote() {
+        Melody garbage = Melody.fromString("garbage", "foo bar baz xyzzy plugh quux");
+        assertArrayEquals(new int[] {5,5,5,5,5,5}, garbage.getNotes());
+    }
+
+    @Test
+    void getId() {
+        String expected = "test-id";
+        Melody withId = new Melody(expected, new int[0]);
+        assertEquals(expected, withId.getId());
     }
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/MultipleSongsMelodyPlayerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/MultipleSongsMelodyPlayerTest.java
@@ -1,0 +1,61 @@
+package com.nicobrailo.pianoli.melodies;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MultipleSongsMelodyPlayerTest {
+    MelodyPlayer player;
+
+    @BeforeEach
+    void initPlayer() {
+        List<Melody> melodies = new ArrayList<>();
+        melodies.add(new Melody("MultiSongPlayerTest_song1>", new int[] {11}));
+        melodies.add(new Melody("MultiSongPlayerTest_song1>", new int[] {22}));
+        melodies.add(new Melody("MultiSongPlayerTest_song1>", new int[] {33}));
+
+        player = new MultipleSongsMelodyPlayer(melodies);
+    }
+
+    @Test
+    void nextNote() {
+        assertEquals(11, player.nextNote());
+        assertEquals(22, player.nextNote());
+        assertEquals(33, player.nextNote());
+
+        assertEquals(11, player.nextNote(),
+                "MultipleSongsMelodyPlayer should loop songs forever");
+    }
+
+    @Test
+    void reset() {
+        assertEquals(11, player.nextNote());
+        assertEquals(22, player.nextNote());
+
+        player.reset();
+
+        assertEquals(11, player.nextNote());
+        assertEquals(22, player.nextNote());
+    }
+
+    @Test
+    void hasNextNote() {
+        assertTrue(player.hasNextNote());
+        assertEquals(11, player.nextNote());
+
+        assertTrue(player.hasNextNote());
+        assertEquals(22, player.nextNote());
+
+        assertTrue(player.hasNextNote());
+        assertEquals(33, player.nextNote());
+        assertFalse(player.hasNextNote()); // after 33, before reset
+
+        player.reset();
+        assertTrue(player.hasNextNote());
+        assertEquals(11, player.nextNote());
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/SingleSongMelodyPlayerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/SingleSongMelodyPlayerTest.java
@@ -1,0 +1,52 @@
+package com.nicobrailo.pianoli.melodies;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SingleSongMelodyPlayerTest {
+    MelodyPlayer player;
+
+    @BeforeEach
+    void initPlayer() {
+        player = new SingleSongMelodyPlayer(new Melody("SingleSongMelodyPlayerTest",
+                new int[] {1,2,3}));
+    }
+
+    @Test
+    void nextNote() {
+        assertEquals(1, player.nextNote());
+        assertEquals(2, player.nextNote());
+        assertEquals(3, player.nextNote());
+
+        assertThrows(NoSuchElementException.class, () -> player.nextNote());
+    }
+
+    @Test
+    void reset() {
+        assertEquals(1, player.nextNote());
+        assertEquals(2, player.nextNote());
+        assertEquals(3, player.nextNote());
+
+        player.reset();
+
+        assertEquals(1, player.nextNote());
+    }
+
+    @Test
+    void hasNextNote() {
+        assertTrue(player.hasNextNote());
+
+        player.nextNote();
+        assertTrue(player.hasNextNote());
+
+        player.nextNote();
+        assertTrue(player.hasNextNote());
+
+        player.nextNote();
+        assertFalse(player.hasNextNote());
+    }
+}


### PR DESCRIPTION
I've been doing some code-coverage-guided test-writing this weekend.
This unveiled some gaps in my previous `Melody` and `SongPlayer` tests.

I've also started working my way through `Piano`.
It feels a bit dirty, because I had to make some edits to "production" logic, in order to make it testable.  
I've been taught that's normally a big no-no (at work).  
For PianOli, I'm willing to break that rule, since I think it's an intermediate step on the way to move sound-playing to `PianoCanvas`.  
The `Canvas` does all the other Android-API-related stuff, while `Piano` is pure coordinate/state-handling if you ignore sounds.

I'm thinking `Piano` will end up with some kind of Listener-pattern, where both the Canvas and the AppConfigTrigger listen for keydown-events. However, it's still crystallizing in my brain.

In the meanwhile, I wanted to publish these additional tests, since they're useful in and of themselves.