### PR TITLE
Bump for release V1.23 - bugfixes + translations.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         // "drawer phones", which are more likely to be given to babies.
         //noinspection OldTargetApi
         targetSdkVersion 33
-        versionCode 22
-        versionName "1.22"
+        versionCode 23
+        versionName "1.23"
     }
 
 

--- a/fastlane/metadata/android/en-US/changelogs/23.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23.txt
@@ -1,0 +1,3 @@
+* New translation: German.
+* Updated translations.
+* Bugfix: Try to fix crash related to screen pinning.


### PR DESCRIPTION
Along with misc chores relating to build scripts, etc, this also includes an attempted fix for #65 and also translations.