### PR TITLE
Bump for release V1.24 - Norwegian Bokmål + Polish

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         // "drawer phones", which are more likely to be given to babies.
         //noinspection OldTargetApi
         targetSdkVersion 33
-        versionCode 23
-        versionName "1.23"
+        versionCode 24
+        versionName "1.24"
     }
 
 

--- a/fastlane/metadata/android/en-US/changelogs/24.txt
+++ b/fastlane/metadata/android/en-US/changelogs/24.txt
@@ -1,0 +1,5 @@
+New translations:
+ * Norwegian Bokmål (thanks @kingu)
+ * Polish (thanks @gnu-ewm)
+
+Want to help translate PianOli into your language? Join us on GitHub and Weblate.


### PR DESCRIPTION
No changes about translations in this PR, they are all merged automatically by Weblate earlier. This just bumps the version number and adds a release note. For reference: After merging, I manually go to Weblate and make the changelog entry in this PR read only. There is nothing stopping us soliciting translations for these changelogs, however that means that we shouldn't tag a release for a week or two after merging to give time for translations. Given the scale of this app, I think it is not really worth the delay and it is better to just tag after merging this PR. As soon as it is tagged, F-Droid will pick up that commit hash, and thus any future translations will not be included by the subsequent F-Droid build. Hence - no need to translate them and any translations from friendly community members will be wasted.