### PR TITLE
Holiday hacking 2: Reshow config toast

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -2,7 +2,6 @@ package com.nicobrailo.pianoli;
 
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
-import android.media.MediaPlayer;
 import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -42,8 +41,6 @@ class AppConfigTrigger implements PianoListener {
      */
     private static final Set<Integer> BLACK_KEYS = new HashSet<>(Arrays.asList(1, 3, 7, 9, 11, 15));
 
-    private final AppCompatActivity activity;
-
     /**
      * Current progress in the unlock sequence: all already-held config-keys.
      *
@@ -71,7 +68,6 @@ class AppConfigTrigger implements PianoListener {
 
     AppConfigTrigger(AppCompatActivity activity) {
         nextExpectedKey = calculateNextExpectedKey();
-        this.activity = activity;
         this.icon = ContextCompat.getDrawable(activity, R.drawable.ic_settings);
         if (this.icon == null) {
             Log.wtf("PianOliError", "Config icon doesn't exist");
@@ -130,18 +126,6 @@ class AppConfigTrigger implements PianoListener {
         pressedConfigKeys.clear();
     }
 
-    private void showConfigDialogue() {
-        final MediaPlayer snd = MediaPlayer.create(activity, R.raw.alert);
-        snd.seekTo(0);
-        snd.setVolume(100, 100);
-        snd.start();
-        snd.setOnCompletionListener(mediaPlayer -> snd.release());
-
-        if (cb != null) {
-            cb.requestConfig();
-        }
-    }
-
     @Override
     public void onKeyDown(int keyIdx) {
         if (keyIdx == nextExpectedKey) {
@@ -156,7 +140,10 @@ class AppConfigTrigger implements PianoListener {
             if (pressedConfigKeys.size() == CONFIG_TRIGGER_COUNT) {
                 // Sequence complete!
                 reset(); // clear the currently tracked state, for next time.
-                showConfigDialogue(); // Open Sesame!
+                // Open Sesame!
+                if (cb != null) {
+                    cb.requestConfig();
+                }
             } else {
                 nextExpectedKey = calculateNextExpectedKey();
             }

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -1,11 +1,6 @@
 package com.nicobrailo.pianoli;
 
-import android.graphics.Canvas;
-import android.graphics.drawable.Drawable;
 import android.util.Log;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -28,9 +23,6 @@ import java.util.Set;
  * </p>
  */
 class AppConfigTrigger implements PianoListener {
-    private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO = 0.5f;
-    private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED = 0.4f;
-
     /** How many of the geared keys must be held before config opens */
     private static final int CONFIG_TRIGGER_COUNT = 2;
 
@@ -56,7 +48,7 @@ class AppConfigTrigger implements PianoListener {
     /**
      * @see #calculateNextExpectedKey()
      */
-    private Integer nextExpectedKey;
+    private int nextExpectedKey;
 
     /**
      * Our "upstream", who knows enougjh about global app context to actually <em>do</em> stuff.
@@ -64,18 +56,28 @@ class AppConfigTrigger implements PianoListener {
     private AppConfigCallback cb = null;
 
     private boolean tooltip_shown = false;
-    private final Drawable icon;
 
-    AppConfigTrigger(AppCompatActivity activity) {
+    AppConfigTrigger() {
         nextExpectedKey = calculateNextExpectedKey();
-        this.icon = ContextCompat.getDrawable(activity, R.drawable.ic_settings);
-        if (this.icon == null) {
-            Log.wtf("PianOliError", "Config icon doesn't exist");
-        }
     }
 
     void setConfigRequestCallback(AppConfigCallback cb) {
         this.cb = cb;
+    }
+
+    /**
+     * @return set of currently-held config keys (defensively copied).
+     */
+    public Set<Integer> getPressedConfigKeys() {
+        return new HashSet<>(pressedConfigKeys);
+    }
+
+    /**
+     * @return currently expected next key in the sequence (without changing it)
+     * @see #calculateNextExpectedKey();
+     */
+    public int getNextExpectedKey() {
+        return nextExpectedKey;
     }
 
     /**
@@ -85,7 +87,7 @@ class AppConfigTrigger implements PianoListener {
      * Ensures already-held keys are not chosen again.
      * </p>
      */
-    private Integer calculateNextExpectedKey() {
+    private int calculateNextExpectedKey() {
         Set<Integer> candidates = new HashSet<>(BLACK_KEYS);
         candidates.removeAll(pressedConfigKeys);
 
@@ -170,19 +172,6 @@ class AppConfigTrigger implements PianoListener {
     @Override
     public void onKeyUp(int keyIdx) {
         reset();
-    }
-
-    /**
-     * Overlays gear icons onto the currently-held and next expected keys.
-     */
-    void drawGears(PianoCanvas pianoCanvas, Canvas androidCanvas) {
-        int pressedSize = (int) (pianoCanvas.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED);
-        for (Integer cfgKey : pressedConfigKeys) {
-            pianoCanvas.draw_icon_on_black_key(androidCanvas, icon, cfgKey, pressedSize, pressedSize);
-        }
-
-        int normalSize = (int) (pianoCanvas.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
-        pianoCanvas.draw_icon_on_black_key(androidCanvas, icon, nextExpectedKey, normalSize, normalSize);
     }
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -24,7 +24,7 @@ import java.util.Set;
  */
 class AppConfigTrigger implements PianoListener {
     /** How many of the geared keys must be held before config opens */
-    private static final int CONFIG_TRIGGER_COUNT = 2;
+    public static final int CONFIG_TRIGGER_COUNT = 2;
 
     /**
      * Candidate keys to receive a gear icon.

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -13,20 +13,64 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+
+/**
+ * Listens for, and defines, the "magic" key combination that unlocks the app, and opens the settings menu.
+ *
+ * <p>
+ * The next key to touch is indicated by a "settings" gear-icon, with already-pressed keys showing a smaller version.
+ * </p>
+ * <p>
+ * The "magic" combination is a random combination of multiple black keys, to be held simultaneously.
+ * The amount of which is defined by {@link #CONFIG_TRIGGER_COUNT} (currently {@value #CONFIG_TRIGGER_COUNT}).
+ * We've chosen a simultaneous-hold koy combo, rather than a serial sequence, because children in our target audience
+ * lack the fine motor skills to achieve it (at least without accidentally triggering a reset by accidentally
+ * brushing another key), but they <em>would</em> be able to trigger a serial sequence by playing "follow the gear".
+ * </p>
+ */
 class AppConfigTrigger implements PianoListener {
     private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO = 0.5f;
     private static final float CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED = 0.4f;
+
+    /** How many of the geared keys must be held before config opens */
     private static final int CONFIG_TRIGGER_COUNT = 2;
+
+    /**
+     * Candidate keys to receive a gear icon.
+     *
+     * <p>Currently a hardcoded set of the first </p>
+     */
     private static final Set<Integer> BLACK_KEYS = new HashSet<>(Arrays.asList(1, 3, 7, 9, 11, 15));
+
     private final AppCompatActivity activity;
+
+    /**
+     * Current progress in the unlock sequence: all already-held config-keys.
+     *
+     * <p>
+     * We need to track which keys are held, not just their amount, to<ol>
+     *     <li>avoid re-selecting them as next candidate key</li>
+     *     <li>draw icons on them.</li>
+     * </ol>
+     * </p>
+     */
     private final Set<Integer> pressedConfigKeys = new HashSet<>();
-    private Integer nextKeyPress;
+
+    /**
+     * @see #calculateNextExpectedKey()
+     */
+    private Integer nextExpectedKey;
+
+    /**
+     * Our "upstream", who knows enougjh about global app context to actually <em>do</em> stuff.
+     */
     private AppConfigCallback cb = null;
+
     private boolean tooltip_shown = false;
     private final Drawable icon;
 
     AppConfigTrigger(AppCompatActivity activity) {
-        nextKeyPress = getNextExpectedKey();
+        nextExpectedKey = calculateNextExpectedKey();
         this.activity = activity;
         this.icon = ContextCompat.getDrawable(activity, R.drawable.ic_settings);
         if (this.icon == null) {
@@ -38,25 +82,49 @@ class AppConfigTrigger implements PianoListener {
         this.cb = cb;
     }
 
-    private Integer getNextExpectedKey() {
-        Set<Integer> nextKeyOptions = new HashSet<>(BLACK_KEYS);
-        nextKeyOptions.removeAll(pressedConfigKeys);
-        int next_key_i = (new Random()).nextInt(nextKeyOptions.size());
+    /**
+     * Chooses the next key that must be held to make progress in the sequence.
+     *
+     * <p>
+     * Ensures already-held keys are not chosen again.
+     * </p>
+     */
+    private Integer calculateNextExpectedKey() {
+        Set<Integer> candidates = new HashSet<>(BLACK_KEYS);
+        candidates.removeAll(pressedConfigKeys);
 
-        for (Integer nextKey : nextKeyOptions) {
-            next_key_i = next_key_i - 1;
-            if (next_key_i <= 0) return nextKey;
+        // Since we cannot easily pick a random selection from a set directly,
+        // (at least not at the low API-level we want to support)
+        // iterate the set to a random depth and select that one.
+        int i = (new Random()).nextInt(candidates.size());
+        for (Integer nextKey : candidates) {
+            i--;
+            if (i <= 0) { return nextKey; }
         }
 
         Log.e("PianOliError", "No next config key possible");
         return -1;
     }
 
+    /**
+     * Resets all progress towards opening the config, back to zero.
+     *
+     * <p>
+     * If any gear-keys were already held, a new expected key is randomly chosen from <em>non-held</em> keys.
+     * This ensures any current touches lose their status as "progress".
+     * </p>
+     *
+     * @see #pressedConfigKeys
+     * @see #calculateNextExpectedKey()
+     */
     private void reset() {
-        // Only do an actual reset if there was some state to reset, otherwise this will select a
-        // new NextExpectedKey and move the icon around whenever the user presses a key
+        // Only change expected keys if there was some progress to reset, otherwise this would select a
+        // new NextExpectedKey and move the icon around whenever the user presses a key.
         if (!pressedConfigKeys.isEmpty()) {
-            nextKeyPress = getNextExpectedKey();
+            // Calculate next expectation *before* clearing pressedConfigKeys, to keep current touches
+            // out of the candidate list. Otherwise, we could accidentally make an already-held key into a 'magic'
+            // key, thereby granting the user unlock-progress without them doing anything to deserve it.
+            nextExpectedKey = calculateNextExpectedKey();
         }
 
         pressedConfigKeys.clear();
@@ -70,47 +138,81 @@ class AppConfigTrigger implements PianoListener {
         snd.setOnCompletionListener(mediaPlayer -> snd.release());
 
         if (cb != null) {
-            cb.onConfigOpenRequested();
+            cb.requestConfig();
         }
     }
 
     @Override
     public void onKeyDown(int keyIdx) {
-        if (keyIdx == nextKeyPress) {
+        if (keyIdx == nextExpectedKey) {
+            // Hint the user at what to do next, if not already done.
             if (!tooltip_shown) {
                 tooltip_shown = true;
-                cb.onShowConfigTooltip();
+                cb.showConfigTooltip();
             }
 
+            // track user's progress in the unlock-sequence
             pressedConfigKeys.add(keyIdx);
             if (pressedConfigKeys.size() == CONFIG_TRIGGER_COUNT) {
-                reset();
-                showConfigDialogue();
+                // Sequence complete!
+                reset(); // clear the currently tracked state, for next time.
+                showConfigDialogue(); // Open Sesame!
             } else {
-                nextKeyPress = getNextExpectedKey();
+                nextExpectedKey = calculateNextExpectedKey();
             }
         } else {
+            // wrong key: force user/child to start from the beginning.
             reset();
         }
     }
 
+    /**
+     * Reset all unlock-sequence progress.
+     *
+     * <p>
+     * Releasing *any* key means we are either<ul>
+     *   <li>aborting our in-progress sequence (released key was a geared one), or</li>
+     *   <li>another 'wrong' key used to be pressed and is now released</li>
+     * </ul>
+     * Either way, we want to force the user to start over, for touching a non-config key.
+     * (A mistake an adult would have been able to avoid, but a child likely wouldn't).
+     * </p>
+     *
+     * @param keyIdx unused for this purpose, all releases are equally 'mistaken'.
+     */
+    @Override
     public void onKeyUp(int keyIdx) {
         reset();
     }
 
-    void onPianoRedrawFinish(PianoCanvas piano, Canvas canvas) {
-        int pressedSize = (int) (piano.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED);
+    /**
+     * Overlays gear icons onto the currently-held and next expected keys.
+     */
+    void drawGears(PianoCanvas pianoCanvas, Canvas androidCanvas) {
+        int pressedSize = (int) (pianoCanvas.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO_PRESSED);
         for (Integer cfgKey : pressedConfigKeys) {
-            piano.draw_icon_on_black_key(canvas, icon, cfgKey, pressedSize, pressedSize);
+            pianoCanvas.draw_icon_on_black_key(androidCanvas, icon, cfgKey, pressedSize, pressedSize);
         }
 
-        int normalSize = (int) (piano.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
-        piano.draw_icon_on_black_key(canvas, icon, nextKeyPress, normalSize, normalSize);
+        int normalSize = (int) (pianoCanvas.piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
+        pianoCanvas.draw_icon_on_black_key(androidCanvas, icon, nextExpectedKey, normalSize, normalSize);
     }
 
+    /**
+     * Decoupling interface, to keep Android-environment awareness out of this Trigger-class.
+     *
+     * <p>
+     * Switching activities, and showing user UI feedback, require a level of global application awareness
+     * that is out of place for this trigger-tracker.
+     * Via this interface, we delegate our required actions to a higher-up that is allowed to have such
+     * awareness.
+     * </p>
+     */
     public interface AppConfigCallback {
-        void onConfigOpenRequested();
+        /** Switch to the Config/Settings Activity */
+        void requestConfig();
 
-        void onShowConfigTooltip();
+        /** Show a hint to the user on how to use the gear icons */
+        void showConfigTooltip();
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -115,7 +115,7 @@ class AppConfigTrigger implements PianoListener {
      * @see #pressedConfigKeys
      * @see #calculateNextExpectedKey()
      */
-    private void reset() {
+    void reset() {
         // Only change expected keys if there was some progress to reset, otherwise this would select a
         // new NextExpectedKey and move the icon around whenever the user presses a key.
         if (!pressedConfigKeys.isEmpty()) {

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -91,6 +91,11 @@ class AppConfigTrigger implements PianoListener {
         Set<Integer> candidates = new HashSet<>(BLACK_KEYS);
         candidates.removeAll(pressedConfigKeys);
 
+        if (candidates.isEmpty()) {
+            Log.e("PianOliError", "No next config key possible");
+            return -1;
+        }
+
         // Since we cannot easily pick a random selection from a set directly,
         // (at least not at the low API-level we want to support)
         // iterate the set to a random depth and select that one.
@@ -100,7 +105,9 @@ class AppConfigTrigger implements PianoListener {
             if (i <= 0) { return nextKey; }
         }
 
-        Log.e("PianOliError", "No next config key possible");
+        // Unreachable due to way candidates.size is upper bound for loop count,
+        // but that's too complicated for the compiler to figure out.
+        // (it can't see through the Random.nextInt() ).
         return -1;
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -9,7 +9,6 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -73,7 +72,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
     private static final int REQUEST_CONFIG = 1;
 
     @Override
-    public void onConfigOpenRequested() {
+    public void requestConfig() {
         // If you've done the dance to press multiple specific buttons at once, no need to keep the screen locked.
         // It will be a minor inconvenience when returning from settings, because it will prompt the user again
         // to lock the app. However the expectation is that the options are not used very often, and the benefit
@@ -85,7 +84,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
     }
 
     @Override
-    public void onShowConfigTooltip() {
+    public void showConfigTooltip() {
         Toast toast = Toast.makeText(getApplicationContext(), R.string.config_tooltip, Toast.LENGTH_LONG);
         toast.show();
     }

--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -2,6 +2,7 @@ package com.nicobrailo.pianoli;
 
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.media.MediaPlayer;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
@@ -69,13 +70,19 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
         lock_app();
     }
 
-    private static final int REQUEST_CONFIG = 1;
-
     @Override
     public void requestConfig() {
+        // play a loud, distinct noise to alert any adults nearby that *someone*
+        // (potentially a half-supervised child) has managed to break out of the app.
+        final MediaPlayer snd = MediaPlayer.create(this, R.raw.alert);
+        snd.seekTo(0);
+        snd.setVolume(100, 100);
+        snd.start();
+        snd.setOnCompletionListener(mediaPlayer -> snd.release());
+
         // If you've done the dance to press multiple specific buttons at once, no need to keep the screen locked.
         // It will be a minor inconvenience when returning from settings, because it will prompt the user again
-        // to lock the app. However the expectation is that the options are not used very often, and the benefit
+        // to lock the app. However, the expectation is that the options are not used very often, and the benefit
         // of having a settings screen work like a more typical Android app probably outweigh the negatives from a
         // child accidentally getting to the settings screen.
         unlock_app();

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -133,7 +133,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             }
         }
 
-        appConfigHandler.onPianoRedrawFinish(this, canvas);
+        appConfigHandler.drawGears(this, canvas);
     }
 
     void draw_key(final Canvas canvas, final Key rect, final Paint p) {

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -299,6 +299,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
      */
     void resetPianoState() {
         touch_pointer_to_keys.clear();
+        appConfigTrigger.reset();
         piano.resetState();
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
@@ -1,0 +1,83 @@
+package com.nicobrailo.pianoli;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Since our config entry sequence is intentionally quite difficult, we should <em>regularly</em>
+ * provide our users with instruction reminders, but not <em>too</em> often, so as not to distract any
+ * children playing.
+ *
+ * <p>
+ *
+ * </p>
+ */
+public class TooltipReminder {
+    /**
+     * Time window (milliseconds) in which repeated unsuccessful config attempts will lead to a reminder tooltip.
+     *
+     *
+     * @see #TRIGGER_COUNT
+     */
+    public static final long COUNTING_WINDOW = TimeUnit.SECONDS.toMillis(5);
+
+    /**
+     * How often a user must unsuccessfully attempt to open the config, before we show a helpful reminder.
+     *
+     * @see #COUNTING_WINDOW
+     */
+    public static final int TRIGGER_COUNT = 3;
+    /**
+     * Start of currently running tooltip reminder time window (epoch millis).
+     *
+     * @see #COUNTING_WINDOW
+     */
+    private long lastAttempt;
+    /**
+     * How many unsuccessful attempts the user made so far. A.K.A. the user's "AAARGH counter".
+     */
+    private int frustration;
+    private final AppConfigTrigger.AppConfigCallback cb;
+
+    public TooltipReminder(AppConfigTrigger.AppConfigCallback cb) {
+        this.cb = cb;
+
+        // Initialise to magic values, that are guaranteed to trigger the very first time
+        // This guarantees the user is reminded at least once every startup.
+        this.frustration = TRIGGER_COUNT - 1; // = one step before overflowing
+        this.lastAttempt = Long.MAX_VALUE;    // = guaranteed to bring our comparisn against 'now' before our timeout.
+    }
+
+    /**
+     * The user tried, but failed, to enter the config.
+     *
+     * <p>
+     * Increases the need for a reminder.
+     * </p>
+     */
+    public void registerFailedAttempt() {
+        long now = getNow();
+
+        if (now - lastAttempt < COUNTING_WINDOW) {
+            // repeated attempt within detection window
+            frustration++;
+        } else {
+            // enough time has passed that frustration is less likely than accidental child bap-bap-bap-ing
+            frustration = 0; // reset
+        }
+        lastAttempt = now;
+
+        if (frustration >= TRIGGER_COUNT) {
+            cb.showConfigTooltip();
+        }
+    }
+
+    /**
+     * Test seam: override to inject fake time for testing.
+     *
+     * @return current time in milliseconds
+     * @see System#currentTimeMillis()
+     */
+    long getNow() {
+        return System.currentTimeMillis();
+    }
+}

--- a/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
@@ -68,6 +68,10 @@ public class TooltipReminder {
 
         if (frustration >= TRIGGER_COUNT) {
             cb.showConfigTooltip();
+
+            // reminder was shown, user should no longer be frustrated
+            // reset the counter to ensure we don't immediately spam reminders on the next hit.
+            frustration = 0;
         }
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/TooltipReminder.java
@@ -25,7 +25,7 @@ public class TooltipReminder {
      *
      * @see #COUNTING_WINDOW
      */
-    public static final int TRIGGER_COUNT = 3;
+    public static final int TRIGGER_COUNT = 5;
     /**
      * Start of currently running tooltip reminder time window (epoch millis).
      *

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -1,0 +1,81 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppConfigTriggerTest {
+    private SpyCallback spyCallback;
+    private AppConfigTrigger trigger;
+
+    @BeforeEach
+    public void setup() {
+        spyCallback = new SpyCallback();
+        trigger = new AppConfigTrigger();
+        trigger.setConfigRequestCallback(spyCallback);
+    }
+
+    @Test
+    public void happyPathWorks() {
+        for (int i = 0; i < AppConfigTrigger.CONFIG_TRIGGER_COUNT; i++) {
+            assertEquals(0, spyCallback.triggerCount,
+                    "Before reaching trigger limit, we should not yet trigger (i=" + i + ")");
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+        }
+        assertEquals(1, spyCallback.triggerCount,
+                "after hitting the required amount of trigger keys, without mistakes, config should trigger.");
+    }
+
+    @Test
+    public void badKeyDownShouldCancelProgress() {
+        for (int i = 0; i < 100; i++) {
+            // make some correct progress
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+            assertTrue(trigger.getPressedConfigKeys().contains(nextExpectedKey),
+                    "Hitting correct key should make progress");
+
+            // "oops"
+            trigger.onKeyDown(Integer.MIN_VALUE); // since any mistake should reset progress, test with an impossible mistake value
+            assertTrue(trigger.getPressedConfigKeys().isEmpty(),
+                    "a bad key-down should reset all progress");
+            assertEquals(0, spyCallback.triggerCount,
+                    "even after a gazillion (i="+i+") bad attempts, we should never trigger");
+        }
+    }
+
+    @Test
+    public void anyKeyUpShouldCancelProgress() {
+        for (int i = 0; i < 50; i++) { // try with a LOT of keys, including some absurdly high ones.
+            // make some correct progress
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+            assertTrue(trigger.getPressedConfigKeys().contains(nextExpectedKey),
+                    "Hitting correct key should make progress");
+
+            // "oops"
+            trigger.onKeyUp(i);
+            assertTrue(trigger.getPressedConfigKeys().isEmpty(),
+                    "a bad key-release should reset all progress");
+            assertEquals(0, spyCallback.triggerCount,
+                    "even after a gazillion (i="+i+") bad attempts, we should never trigger");
+        }
+    }
+
+    static class SpyCallback implements AppConfigTrigger.AppConfigCallback {
+        int triggerCount = 0;
+        int toastCount = 0;
+
+        @Override
+        public void requestConfig() {
+            triggerCount++;
+        }
+
+        @Override
+        public void showConfigTooltip() {
+            toastCount++;
+        }
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -64,6 +64,27 @@ class AppConfigTriggerTest {
         }
     }
 
+    /**
+     * When touching any key that <em>isn't</em> a config key, the next expected key
+     * should remain constant, to avoid the gear icon twitching on every key-press.
+     */
+    @Test
+    public void gearIconShouldntTwitch() {
+        int originalConfigKey = trigger.getNextExpectedKey();
+        int pianoSize = 50; // given our wonderfully decoupled interface, this is all the piano-mock we need :-D
+
+        for (int i = 0; i < pianoSize; i++) {
+            if (i == originalConfigKey) {
+                continue; // skip the ONE key we're actually listening for
+            }
+            trigger.onKeyDown(i); // trigger all other keys
+            assertEquals(originalConfigKey, trigger.getNextExpectedKey(),
+                    "Expected key should change ONLY if the current expected key is triggered." +
+                            "(to prevent distracting visual twitches of the icon under normal use)");
+        }
+    }
+
+
     static class SpyCallback implements AppConfigTrigger.AppConfigCallback {
         int triggerCount = 0;
         int toastCount = 0;

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -26,6 +26,12 @@ class AppConfigTriggerTest {
         }
         assertEquals(1, spyCallback.triggerCount,
                 "after hitting the required amount of trigger keys, without mistakes, config should trigger.");
+
+        assertTrue(trigger.getPressedConfigKeys().isEmpty(),
+                "unlock should clear the pressed-state for the successful sequence.\n" +
+                        "Our unlock instruction reminder counts key-ups of config keys, to track \"user frustration\".\n" +
+                        "Thus, it is important that key-ups of <em>successful</em> unlocks (hopefully a non-frustrating event),\n" +
+                        "clear state before they are accidentally counted.");
     }
 
     @Test
@@ -85,18 +91,4 @@ class AppConfigTriggerTest {
     }
 
 
-    static class SpyCallback implements AppConfigTrigger.AppConfigCallback {
-        int triggerCount = 0;
-        int toastCount = 0;
-
-        @Override
-        public void requestConfig() {
-            triggerCount++;
-        }
-
-        @Override
-        public void showConfigTooltip() {
-            toastCount++;
-        }
-    }
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/SpyCallback.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/SpyCallback.java
@@ -1,0 +1,16 @@
+package com.nicobrailo.pianoli;
+
+class SpyCallback implements AppConfigTrigger.AppConfigCallback {
+    int triggerCount = 0;
+    int toastCount = 0;
+
+    @Override
+    public void requestConfig() {
+        triggerCount++;
+    }
+
+    @Override
+    public void showConfigTooltip() {
+        toastCount++;
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/TooltipReminderTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/TooltipReminderTest.java
@@ -1,0 +1,87 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class TooltipReminderTest {
+
+    private SpyCallback spyCallback;
+    private TestableTooltipReminder reminder;
+
+    @BeforeEach
+    public void setup() {
+        spyCallback = new SpyCallback();
+        reminder = new TestableTooltipReminder(spyCallback);
+    }
+
+
+    @Test
+    public void firstTouchShouldTrigger() {
+        reminder.registerFailedAttempt();
+        assertEquals(1, spyCallback.toastCount,
+                "First touch of a config key after init should show a reminder, to preserve old behaviour.");
+    }
+
+    @Test
+    public void slowTouchesDontTrigger() {
+        long slowInterval = TooltipReminder.COUNTING_WINDOW + 1;
+
+        // get initial reminder-trigger out of the way
+        reminder.registerFailedAttempt();
+
+        for (int i = 0; i < 10; i++) {
+            reminder.nextNow += slowInterval; // "time passes"
+            reminder.registerFailedAttempt(); // user acts
+            assertEquals(1, spyCallback.toastCount,
+                    "slow hits of the config keys shouldn't trigger a reminder");
+        }
+    }
+
+    @Test
+    public void fastTouchesDoTrigger() {
+        long fastInterval = TooltipReminder.COUNTING_WINDOW - 1;
+
+        // get initial reminder-trigger out of the way
+        reminder.registerFailedAttempt();
+
+        // simulate nothing happening for a while, or only normal piano playing
+        reminder.nextNow += TooltipReminder.COUNTING_WINDOW + 1;
+
+        // prime the pump: attempts until just before we start triggering
+        for (int i = 0; i < TooltipReminder.TRIGGER_COUNT; i++) {
+            reminder.registerFailedAttempt();
+        }
+        assertEquals(1, spyCallback.toastCount,
+                "after a long-ish time of inactivity, failed attempts should not immediately trigger " +
+                        "(to avoid distraction on accidental presses).");
+
+        for (int i = 1; i <= 10; i++) { // gotacha: one-based counting! (for easier loop counting, below
+            reminder.nextNow += fastInterval; // "time passes", but not enough
+            reminder.registerFailedAttempt(); // user acts
+            assertEquals(1 + i, spyCallback.toastCount, // 1 base reminder, plus our loop count
+                    "slow hits of the config keys shouldn't trigger a reminder");
+        }
+    }
+
+
+    /** Testable version of {@link TooltipReminder}, with manipulable clock */
+    static class TestableTooltipReminder extends TooltipReminder {
+        /** fake time-value, for easier testing of time-related logic */
+        public long nextNow = 0;
+
+        public TestableTooltipReminder(AppConfigTrigger.AppConfigCallback cb) {
+            super(cb);
+        }
+
+        /**
+         * @return fake time, namely {@link #nextNow}
+         */
+        @Override
+        long getNow() {
+            return nextNow;
+        }
+    }
+}


### PR DESCRIPTION
More holiday hacking! 
This builds on, and includes, the refactoring in #83. That should be reviewed and merged before considering this one. 

This disassembles the different responsibilities of `AppConfigTrigger`, and moves them to new places:
  - trigger alert sound moves up to the `MainActivity` callback, so we lose a dependency on the Android context
  - Gear-drawing logic moves into `PianoCanvas`, together with all the other draw-calls (completely ridding us of Context) 
  - now that we no longer need to mock contexts, the Trigger is suddenly testable! 
  - replace the simple `configure shown` boolean with a more powerful "frustration tracker" as brainstormed in #77 
    - tracks config-touches in a 5 second window
    - resets on any non-config key
    - re-shows config toast after 5 config keys (so on hitting the 6th)

Closes #77 