### PR TITLE
Holiday Hacking 3: Leak hunting with strict mode

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.pm.ActivityInfo;
 import android.media.MediaPlayer;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
@@ -72,6 +73,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
 
     @Override
     public void requestConfig() {
+        Log.i("PianOli::main", "opening config");
         // play a loud, distinct noise to alert any adults nearby that *someone*
         // (potentially a half-supervised child) has managed to break out of the app.
         final MediaPlayer snd = MediaPlayer.create(this, R.raw.alert);

--- a/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/MainActivity.java
@@ -94,7 +94,7 @@ public class MainActivity extends AppCompatActivity implements AppConfigTrigger.
 
     @Override
     public void showConfigTooltip() {
-        Toast toast = Toast.makeText(getApplicationContext(), R.string.config_tooltip, Toast.LENGTH_LONG);
+        Toast toast = Toast.makeText(this, R.string.config_tooltip, Toast.LENGTH_LONG);
         toast.show();
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -52,6 +52,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
     private final Theme theme;
 
     private Map<Integer, Integer> touch_pointer_to_keys = new HashMap<>();
+    private SoundSet soundSet;
 
     public PianoCanvas(Context context, AttributeSet as) {
         this(context, as, 0);
@@ -77,12 +78,12 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
         screen_size_x = screen_size.x;
         screen_size_y = screen_size.y;
-        final String soundset = Preferences.selectedSoundSet(context);
+        final String prefSoundset = Preferences.selectedSoundSet(context);
 
         // DANGER ZONE: !! delicate ordering dependencies in this block !!
         appConfigTrigger = new AppConfigTrigger();
         // gotcha: gets just-created appConfigHandler via field
-        reInitPiano(context, soundset); // danger: impl leaks `this` pointer before ctor finished
+        reInitPiano(context, prefSoundset); // danger: impl leaks `this` pointer before ctor finished
         // gotcha: needs piano field that was just initialised by reInitPiano above
         this.bevelWidth = piano.get_keys_width() * BEVEL_RATIO;
 
@@ -96,7 +97,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
                 ", there are " + piano.get_keys_count() + " keys");
     }
 
-    public void reInitPiano(Context context, String soundset) {
+    public void reInitPiano(Context context, String prefSoundset) {
         Log.i("PianOli::PianoCanvas", "re-initialising Piano");
         this.piano = new Piano(screen_size_x, screen_size_y);
 
@@ -106,9 +107,12 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         // to redraw on key-touches, must be after config handler to ensure its input is also drawn
         piano.addListener(this);
 
+        if (soundSet != null) {
+            soundSet.close();
+        }
         // Respond musically to key-presses: listen with a "soundMaker"
         // Use "strategy pattern" to deal with the two possible key-to-note mappings:
-        SoundSet soundSet = new SampledSoundSet(context, soundset);
+        soundSet = new SampledSoundSet(context, prefSoundset);
         PianoListener soundMaker;
         if (Preferences.areMelodiesEnabled(context)) {
             // "melodic" strategy: next note is determined by melody

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -71,7 +71,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             Display display = ctx.getWindowManager().getDefaultDisplay();
             display.getSize(screen_size);
         } catch (ClassCastException ex) {
-            Log.e("PianOli::DrawingCanvas", "Can't read screen size");
+            Log.e("PianOli::PianoCanvas", "Can't read screen size");
             throw ex;
         }
 
@@ -97,6 +97,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
     }
 
     public void reInitPiano(Context context, String soundset) {
+        Log.i("PianOli::PianoCanvas", "re-initialising Piano");
         this.piano = new Piano(screen_size_x, screen_size_y);
 
         // for config trigger updates
@@ -119,6 +120,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             soundMaker = new StraightKeySoundMaker(soundSet);
         }
         piano.addListener(soundMaker);
+        Log.i("PianOli::PianoCanvas", "re-initialising Piano - DONE");
     }
 
     public void setConfigRequestCallback(AppConfigTrigger.AppConfigCallback cb) {
@@ -259,6 +261,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
     @Override
     public void surfaceCreated(@NonNull SurfaceHolder surfaceHolder) {
+        Log.i("PianOli::PianoCanvas", "surfaceCreated");
         redraw(surfaceHolder);
     }
 
@@ -382,8 +385,12 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
 
     @Override
-    public void surfaceChanged(@NonNull SurfaceHolder surfaceHolder, int i, int i1, int i2) {}
+    public void surfaceChanged(@NonNull SurfaceHolder surfaceHolder, int i, int i1, int i2) {
+        Log.i("PianOli::PianoCanvas", "surfaceChanged: ignoring!");
+    }
 
     @Override
-    public void surfaceDestroyed(@NonNull SurfaceHolder surfaceHolder) {}
+    public void surfaceDestroyed(@NonNull SurfaceHolder surfaceHolder) {
+        Log.i("PianOli::PianoCanvas", "surfaceDestroyed: ignoring!");
+    }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/SettingsFragment.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/SettingsFragment.java
@@ -42,7 +42,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             Toast toast = Toast.makeText(context, msg, Toast.LENGTH_LONG);
             toast.show();
 
-            Log.d("PianOli::Activity", "Sound assets not available: piano will have no sound!");
+            Log.e("PianOli::Settings", "Sound assets not available: piano will have no sound!");
         }
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/sound/SampledSoundSet.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/sound/SampledSoundSet.java
@@ -19,7 +19,7 @@ import java.util.Locale;
  * object, and replace it with a new instance.
  * </p>
  */
-public class SampledSoundSet implements AutoCloseable, SoundSet {
+public class SampledSoundSet implements SoundSet {
     /**
      * The amount of samples/notes in each sound-set.
      *
@@ -39,8 +39,11 @@ public class SampledSoundSet implements AutoCloseable, SoundSet {
      * Resource handles to the mp3 samples of our currently active soundset, one for each note
      */
     private final int[] samples;
+    private final String name;
 
     public SampledSoundSet(final Context context, String soundSetName) {
+        this.name = soundSetName;
+
         pool = new SoundPool.Builder()
                 .setMaxStreams(7)   // Play max N concurrent sounds
                 .build();
@@ -98,6 +101,7 @@ public class SampledSoundSet implements AutoCloseable, SoundSet {
 
     @Override
     public void close() {
+        Log.d("PianOli::SoundSet", "releasing soundset " + name);
         pool.release();
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/sound/SampledSoundSet.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/sound/SampledSoundSet.java
@@ -1,6 +1,7 @@
 package com.nicobrailo.pianoli.sound;
 
 import android.content.Context;
+import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
 import android.media.SoundPool;
 import android.util.Log;
@@ -90,7 +91,9 @@ public class SampledSoundSet implements AutoCloseable, SoundSet {
     private static int loadNoteFd(AssetManager am, SoundPool pool, String soundSetName, int noteNum) throws IOException {
         String assetFolder = "sounds/" + SoundSet.addPrefix(soundSetName) + "/";
         String fileName = String.format(Locale.ROOT, "n%02d.mp3", noteNum); // root locale OK for number-formatting.
-        return pool.load(am.openFd(assetFolder + fileName), 1);
+        try (AssetFileDescriptor afd = am.openFd(assetFolder + fileName)) {
+            return pool.load(afd, 1);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/nicobrailo/pianoli/sound/SoundSet.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/sound/SoundSet.java
@@ -9,10 +9,8 @@ import java.util.List;
 
 /**
  * {@link SoundSet}s represent PianOli's capability to make musical noise in response to keypresses.
- *
- * This interface
  */
-public interface SoundSet {
+public interface SoundSet extends AutoCloseable {
     /**
      * prefix for soundset stuff, both of asset-folders containing instrument samples and translation string keys.
      *
@@ -74,4 +72,6 @@ public interface SoundSet {
     }
 
     void playNote(int keyIdx);
+
+    void close();
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/sound/SpySoundSet.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/sound/SpySoundSet.java
@@ -1,7 +1,5 @@
 package com.nicobrailo.pianoli.sound;
 
-import com.nicobrailo.pianoli.sound.SoundSet;
-
 /**
  * observable dummy {@link SoundSet}, for test purposes.
  */
@@ -12,5 +10,10 @@ public class SpySoundSet implements SoundSet {
     @Override
     public void playNote(int keyIdx) {
         lastPlayed = keyIdx;
+    }
+
+    @Override
+    public void close() {
+        // dummy implementation, do nothing
     }
 }


### PR DESCRIPTION
I recently learned about Android-API [`StrictMode`](https://developer.android.com/reference/android/os/StrictMode):

> StrictMode is a developer tool which detects things you might be doing by accident and brings them to your attention so you can fix them. 

This builds on my previous "holiday hacking" MRs: #83, #84, so it *appears* giant, but in reality you should only look at the last 4 commits, and only after the previous two were merged)

I've enabled it locally, and ran PianOli in the emulator. There are a few obvious things we can improve:

1. Our config-access Toast was using a non-UI-enabled interface to the application context. It still _worked_ because the runtime context-object also has the UI-interface, but that was by accident, not by design.
  We fix it by passing the exact same context (`MainActivity`, but directly, so that the compiler sees the UI-interfaces as well)
2. We didn't close the file-descriptors we used to load our sound samples, solved with `try-with` auto-closeables.
3. My newly extracted `SoundSet` wraps a releasable resource (Android `SoundPool`), so needs to be disposed of as well.
   (Same problem existed when the `SoundPool` still lived in `Piano`, it just wasn't as obvious)