### PR TITLE
Consistency checks for dynamic strings, before adding "Frère Jacques" song. 

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import androidx.core.graphics.ColorUtils;
 
 public class Theme {
+    public static final String PREFIX = "theme_";
 
     private final KeyColor[] colors;
 

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -5,6 +5,7 @@ import com.nicobrailo.pianoli.song.ImALittleTeapot;
 import com.nicobrailo.pianoli.song.InsyWinsySpider;
 import com.nicobrailo.pianoli.song.TwinkleTwinkleLittleStar;
 import com.nicobrailo.pianoli.song.WaltzingMatilda;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Parsed representation of a children's song.
@@ -30,7 +31,7 @@ public class Melody {
             TwinkleTwinkleLittleStar.melody,
             InsyWinsySpider.melody,
             ImALittleTeapot.melody,
-            WaltzingMatilda.melody
+            WaltzingMatilda.melody,
     };
 
     /**
@@ -77,5 +78,13 @@ public class Melody {
 
     public int[] getNotes() {
         return notes;
+    }
+
+    @NotNull
+    @Override
+    public String toString() {
+        return "Melody{" +
+                '\'' + id + '\'' +
+                ", " + notes.length + " notes}";
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -1,10 +1,7 @@
 package com.nicobrailo.pianoli.melodies;
 
 import android.util.Log;
-import com.nicobrailo.pianoli.song.ImALittleTeapot;
-import com.nicobrailo.pianoli.song.InsyWinsySpider;
-import com.nicobrailo.pianoli.song.TwinkleTwinkleLittleStar;
-import com.nicobrailo.pianoli.song.WaltzingMatilda;
+import com.nicobrailo.pianoli.song.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -32,6 +29,7 @@ public class Melody {
             InsyWinsySpider.melody,
             ImALittleTeapot.melody,
             WaltzingMatilda.melody,
+            BrotherJohn.melody,
     };
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/Melody.java
@@ -15,6 +15,8 @@ public class Melody {
     /** Log tag */
     public static final String TAG = "MELODY";
 
+    public static final String PREFIX = "melody_";
+
     /**
      * All songs known to PianOli.
      *

--- a/app/src/main/java/com/nicobrailo/pianoli/song/BrotherJohn.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/song/BrotherJohn.java
@@ -1,0 +1,44 @@
+package com.nicobrailo.pianoli.song;
+
+import com.nicobrailo.pianoli.melodies.Melody;
+
+/**
+ * The massively translated Frère Jacques ("Are you sleeping, Brother John?")
+ *
+ * <p>
+ * This nursery rhyme has been translated to dozens of languages, so it should reach a very wide audience.
+ * </p>
+ *
+ * <p>
+ * Compared to the classic C-D-E-C arrangement, this version is up-shifted by three full notes,
+ * to account for the bass-note the final chord. Without this shift, it would fall below where we have sound samples.
+ * </p>
+ *
+ *
+ * <p>
+ * Further reading:<ul>
+ * <li><a href="https://en.wikipedia.org/wiki/Fr%C3%A8re_Jacques">English Wikipedia: Frère Jacques</a></li>
+ * <li><a href="https://de.wikipedia.org/wiki/Fr%C3%A8re_Jacques">German Wikipedia: Frère Jacques</a>  (listing some 50 translations)</li>
+ * </ul></p>
+ */
+public class BrotherJohn {
+    public static final Melody melody = Melody.fromString(
+            "brother_john",
+            " " + // 'useless' string so that code formatting indentation nicely lines up
+                    // Are you sleeping, 2x
+                    "F G A F " +
+                    "F G A F " +
+
+                    // Brother John? 2x
+                    "A A# C2 " +
+                    "A A# C2 " +
+
+                    // Morning bells are ringing! 2x
+                    "C2 D2 C2 A# A F " +
+                    "C2 D2 C2 A# A F " +
+
+                    // Please come on! 2x
+                    "F C F " +
+                    "F C F "
+    );
+}

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -24,4 +24,5 @@
     <string name="theme_black_and_white">schwarz-weiß</string>
     <string name="melody_twinkle_twinkle_little_star">Morgen kommt der Weihnachtsmann</string>
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
+    <string name="soundset_piano2">Piano 2</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -25,4 +25,5 @@
     <string name="melody_twinkle_twinkle_little_star">Morgen kommt der Weihnachtsmann</string>
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
     <string name="soundset_piano2">Piano 2</string>
+    <string name="melody_brother_john">Bruder Jakob</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -30,4 +30,5 @@
     <string name="melody_im_a_little_teapot">Ik ben een Kleine Theepot</string>
     <string name="preferences">Voorkeuren</string>
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
+    <string name="soundset_piano2">Piano 2</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -31,4 +31,5 @@
     <string name="preferences">Voorkeuren</string>
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
     <string name="soundset_piano2">Piano 2</string>
+    <string name="melody_brother_john">Vader Jacob</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="melody_im_a_little_teapot">I\'m a Little Teapot</string>
     <string name="melody_insy_winsy_spider">Incy Winsy Spider</string>
     <string name="melody_waltzing_matilda">Waltzing Matilda</string>
+    <string name="melody_brother_john">Brother John</string>
 
     <!-- keyboard colour themes -->
     <string name="theme">Key Colours</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,8 +17,10 @@
     <string name="soundset_guitar">Guitar</string>
     <string name="soundset_musicbox">Music Box</string>
     <string name="soundset_piano">Piano</string>
+    <string name="soundset_piano2">Piano 2</string>
     <string name="soundset_sine">Sine Wave</string>
     <string name="soundset_vibraphone">Vibraphone</string>
+
 
     <!-- Song player settings -->
     <string name="pref_enable_melodies">Auto play melodies</string>

--- a/app/src/test/java/com/nicobrailo/pianoli/AssertionsExt.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AssertionsExt.java
@@ -1,0 +1,16 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Collection;
+
+public class AssertionsExt {
+    /**
+     * Fails (with <code>message</code>) if collection <code>haystack</code> does not contain <code>needle</code>.
+     */
+    public static <T> void assertContains(Collection<T> haystack, T needle, String message) {
+        if (!haystack.contains(needle)) {
+            Assertions.fail(message);
+        }
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
@@ -5,7 +5,6 @@ import android.content.res.AssetManager;
 import com.nicobrailo.pianoli.melodies.Melody;
 import com.nicobrailo.pianoli.sound.SoundSet;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -16,11 +15,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.nicobrailo.pianoli.AssertionsExt.*;
 
 /**
  * Consistency checks for dynamically-accessed entities: do they have translation-strings?
@@ -163,15 +163,6 @@ public class DynamicTranslationIdentifierTest {
         assertContains(melodies, matchingForm,
                 "Translation id '" + translationIdentifier + "' translates a melody that doesn't exist in Melody.java " +
                         "(" + melodies + ")");
-    }
-
-    /**
-     * Fails (with <code>message</code>) if collection <code>haystack</code> does not contain <code>needle</code>.
-     */
-    public <T> void assertContains(Collection<T> haystack, T needle, String message) {
-        if (!haystack.contains(needle)) {
-            Assertions.fail(message);
-        }
     }
 
     /**

--- a/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
@@ -1,0 +1,126 @@
+package com.nicobrailo.pianoli;
+
+import android.content.res.AssetManager;
+import com.nicobrailo.pianoli.sound.SoundSet;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Consistency checks for dynamically-accessed entities: do they have translation-strings?
+ *
+ * <p>There are a few entities in PianOli that are derived dynamically at runtime.
+ * The IDE/Compiler cannot us in ensuring these have internationalisation strings, or that a particular string
+ * is never used.
+ * These unit tests cover those holes for the following entities:
+ * <ul>
+ *     <li>SoundSets</li>
+ * </ul>
+ * </p>
+ */
+public class DynamicTranslationIdentifierTest {
+    /**
+     * Ensures that all available {@link com.nicobrailo.pianoli.sound.SampledSoundSet}s are translatable.
+     *
+     * <p>
+     * It does so by checking if each "soundset_FOO" folder under <code>src/main/assets/</code> has
+     * a matching entry in <code>src/main/res/values/strings.xml</code>.
+     * </p>
+     * <p>
+     * We do <em>not</em> test if the translation exists in all languages; test-failures due to (lack of) translation
+     * progress is a distraction, and not something the developer can control.
+     * Instead, we ensure that
+     * </p>
+     *
+     * @see com.nicobrailo.pianoli.sound.SampledSoundSet
+     * @see SoundSet#PREFIX
+     * @see SoundSet#getAvailableSoundsets(AssetManager)
+     * @see SettingsFragment#loadSounds()
+     */
+    @ParameterizedTest
+    @MethodSource("getSoundSets")
+    public void testSoundsetsHaveTranslationEntities(Path soundsetAssetFolder) {
+        List<String> translatables = getSoundSetTranslations();
+
+        String folderName = soundsetAssetFolder.getFileName().toString();
+
+        assertContains(translatables, folderName,
+                "Asset folder '" + soundsetAssetFolder + "' has no translation string in app/src/main/res/values/strings.xml");
+    }
+
+    /**
+     * Ensures our translations actually have a soundset backing them.
+     *
+     * <p>
+     * Inverse of {@link #testSoundsetsHaveTranslationEntities(Path)}, useful if we rename or delete asset folders.
+     * </p>
+     */
+    @ParameterizedTest
+    @MethodSource("getSoundSetTranslations")
+    public void testNoLeftoverSoundSetTranslations(String translationIdentifier) throws IOException {
+        List<String> soundSetAssets = getSoundSets().stream()
+                .map(Path::getFileName)
+                .map(Path::toString)
+                .collect(Collectors.toList());
+
+        assertContains(soundSetAssets, translationIdentifier,
+                "Translation id '" + translationIdentifier + "' translates a soundset that doesn't exist in src/main/assets/");
+    }
+
+
+    /**
+     * Fails (with <code>message</code>) if collection <code>haystack</code> does not contain <code>needle</code>.
+     */
+    public <T> void assertContains(Collection<T> haystack, T needle, String message) {
+        if (!haystack.contains(needle)) {
+            Assertions.fail(message);
+        }
+    }
+
+    /**
+     * Scans the primary translation string source for identifiers starting with <code>prefix</code>
+     */
+    private static List<String> getTranslationsByPrefix(String prefix) {
+        // All String-resource identifiers
+        Field[] allStrings = R.string.class.getFields();
+
+        return Arrays.stream(allStrings)
+                .map(Field::getName)
+                .filter(name -> name.startsWith(prefix))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@link MethodSource} for all soundset translation identifiers
+     */
+    public static List<String> getSoundSetTranslations() {
+        return getTranslationsByPrefix(SoundSet.PREFIX);
+    }
+
+    /**
+     * {@link MethodSource} for all soundset asset folders
+     */
+    @NotNull
+    public static List<Path> getSoundSets() throws IOException {
+        Path soundAssets = Paths.get("src/main/assets/sounds"); // app-tests run in app-folder (at least on my IDE)
+
+        try (Stream<Path> pathStream = Files.list(soundAssets)) {
+            return pathStream
+                    .filter(Files::isDirectory) // skip top-level files (specifically: "source" attribution file)
+                    .filter(path -> path.getFileName().toString().startsWith(SoundSet.PREFIX))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
@@ -2,6 +2,7 @@ package com.nicobrailo.pianoli;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import com.nicobrailo.pianoli.melodies.Melody;
 import com.nicobrailo.pianoli.sound.SoundSet;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
@@ -31,6 +32,7 @@ import java.util.stream.Stream;
  * <ul>
  *     <li>SoundSets</li>
  *     <li>Themes</li>
+ *     <li>Melodies</li>
  * </ul>
  * </p>
  */
@@ -123,6 +125,46 @@ public class DynamicTranslationIdentifierTest {
                         "(" + themes + ")");
     }
 
+
+    /**
+     * Ensures that all specific {@link Melody Melodies} are translatable.
+     *
+     * @see Melody
+     * @see Melody#PREFIX
+     * @see Melody#all
+     * @see SettingsFragment#loadMelodies()
+     */
+    @ParameterizedTest
+    @MethodSource("getMelodies")
+    public void testMelodiesHaveTranslationEntities(String melodyId) {
+        List<String> translatables = getMelodyTranslations();
+
+        String matchingForm = Melody.PREFIX + melodyId.toLowerCase(Locale.ROOT);
+        assertContains(translatables, matchingForm,
+                "Melody '" + melodyId + "' has no translation string ('" + matchingForm + "') in app/src/main/res/values/strings.xml");
+    }
+
+
+    /**
+     * Ensures our translations actually have a melody backing them.
+     *
+     * <p>
+     * Inverse of {@link #testMelodiesHaveTranslationEntities(String)}, useful if we rename or delete melodies.
+     * </p>
+     */
+    @ParameterizedTest
+    @MethodSource("getMelodyTranslations")
+    public void testNoLeftoverMelodyTranslations(String translationIdentifier) {
+        List<String> melodies = getMelodies();
+
+        String matchingForm = translationIdentifier
+                .replaceFirst("^" + Melody.PREFIX, "");
+
+        assertContains(melodies, matchingForm,
+                "Translation id '" + translationIdentifier + "' translates a melody that doesn't exist in Melody.java " +
+                        "(" + melodies + ")");
+    }
+
     /**
      * Fails (with <code>message</code>) if collection <code>haystack</code> does not contain <code>needle</code>.
      */
@@ -185,6 +227,20 @@ public class DynamicTranslationIdentifierTest {
                 .filter(field -> Theme.class.equals(field.getType()))
                 .filter(field -> Modifier.isStatic(field.getModifiers()))
                 .map(Field::getName)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * {@link MethodSource} for all melody translation identifiers
+     */
+    public static List<String> getMelodyTranslations() {
+        return getTranslationsByPrefix(Melody.PREFIX);
+    }
+
+    public static List<String> getMelodies() {
+        return Arrays.stream(Melody.all)
+                .map(Melody::getId)
                 .collect(Collectors.toList());
     }
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/MelodyTest.java
@@ -1,11 +1,19 @@
 package com.nicobrailo.pianoli.melodies;
 
+import com.nicobrailo.pianoli.AssertionsExt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,5 +49,65 @@ class MelodyTest {
         String expected = "test-id";
         Melody withId = new Melody(expected, new int[0]);
         assertEquals(expected, withId.getId());
+    }
+
+
+    /**
+     * Very poor substitute for classpath scanning: just iterate java-files in the right source folder
+     *
+     * <p>
+     * Works because:<ol>
+     * </ol>
+     *      <li>only one folder to scan</li>
+     *      <li>one song per java file convention</li>
+     *      <li>filename to melody-id mapping convention</li>
+     * </p>
+     */
+    public static List<Path> enumerateAllSongFiles() throws IOException {
+        Path songSourceFolder = Paths.get("src", "main", "java", "com/nicobrailo/pianoli", "song");
+
+        try (Stream<Path> songStream = Files.list(songSourceFolder)) {
+            return songStream
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .collect(Collectors.toList());
+        }
+    }
+
+
+    /**
+     * Checks if all programmed melodies are also registered in the runtime-available list: {@link Melody#all}.
+     *
+     * <p>
+     * This way, we can't forget the required manual step to make a song actually available at runtime.
+     * </p>
+     * <p>
+     * We want to avoid classpath scanning for melodies, since that´s a very big dependency for such a tiny use-case.
+     * Furthermore, the simple folder-scanning we do here is next to impossible to do at runtime, since the Android API
+     * doesn't really give us raw file access.<br>
+     * Thus, ensure our available-at-runtime-list is in sync with the filesystem during tests, when we have
+     * 'normal', android-free java, and full filesystem access.
+     * </p>
+     *
+     * @see Melody#all
+     * @see #enumerateAllSongFiles()
+     */
+    @ParameterizedTest
+    @MethodSource("enumerateAllSongFiles")
+    void testAllSongsAreRegistered(Path songJavaPath) {
+        List<String> registeredMelodiesMatchingFOrm = Arrays.stream(Melody.all)
+                .map(Melody::getId)
+                .map(id -> id.replaceAll("_", ""))
+                .collect(Collectors.toList());
+
+        String fileMatchingForm = songJavaPath
+                .getFileName()
+                .toString()
+                .replaceFirst("\\.java$", "")
+                .toLowerCase(Locale.ROOT);
+
+        AssertionsExt.assertContains(registeredMelodiesMatchingFOrm, fileMatchingForm,
+                "Song file " + songJavaPath + " is not registered in hardcoded Melody.all " +
+                        "(" + Arrays.toString(Melody.all) + ")");
     }
 }


### PR DESCRIPTION
Ever since @pserwylo added the song-player in #28, I've wanted to add Frère Jacques ("are you sleeping, brother John").
I am 99% sure it has translations for all European languages, as since it definitely has Spanish, English and Chinese, we reach probably 75% of all living humans on the planet.

However, adding songs requires updating quite a few hardcoded strings in multiple places. Since I dislike "you just have to know where" as an answer, especially for open source projects hoping for new contributors, I've added unit tests that check these implicit consistency rules. 

It's definitely not perfect, but I think it covers most cases: