### PR TITLE
Enum-ify `Theme`.

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -165,11 +165,11 @@ public class Piano {
         if (pos_y > keys_flats_height) return big_key_idx;
 
         // Check if press is inside rect of flat key
-        Key flat = get_area_for_flat_key(big_key_idx);
+        Key flat = getAreaForSmallKey(big_key_idx + 1);
         if (flat.contains(pos_x, pos_y)) return big_key_idx + 1;
 
         if (big_key_idx > 0) {
-            Key prev_flat = get_area_for_flat_key(big_key_idx - 2);
+            Key prev_flat = getAreaForSmallKey(big_key_idx - 1);
             if (prev_flat.contains(pos_x, pos_y)) return big_key_idx - 1;
         }
 
@@ -177,20 +177,31 @@ public class Piano {
         return big_key_idx;
     }
 
-    Key get_area_for_key(int key_idx) {
-        int x_i = key_idx / 2 * keys_width;
+    @NonNull
+    Key getAreaForKey(int keyIdx) {
+        if ((keyIdx & 1) == 0) { // even positions are the full, big keys
+            return getAreaForBigKey(keyIdx);
+        } else {
+            return getAreaForSmallKey(keyIdx); // odd positions are the small/black/flat keys.
+        }
+    }
+
+    @NonNull
+    private Key getAreaForBigKey(int keyIdx) {
+        int x_i = keyIdx / 2 * keys_width;
         return new Key(x_i, x_i + keys_width, 0, keys_height);
     }
 
-    Key get_area_for_flat_key(int key_idx) {
-        final int octave_idx = (key_idx / 2) % 7;
-        if (octave_idx == 2 || octave_idx == 6) {
+    @NonNull
+    private Key getAreaForSmallKey(int keyIdx) {
+        final int octaveIdx = (keyIdx / 2) % 7;
+        if (octaveIdx == 2 || octaveIdx == 6) {
             // Keys without flat get a null-area
             return Key.CANT_TOUCH_THIS;
         }
 
         final int offset = keys_width - (keys_flat_width / 2);
-        int x_i = (key_idx / 2) * keys_width + offset;
+        int x_i = (keyIdx / 2) * keys_width + offset;
         return new Key(x_i, x_i + keys_flat_width, 0, keys_flats_height);
     }
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -98,7 +98,9 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
     public void reInitPiano(Context context, String prefSoundset) {
         Log.i("PianOli::PianoCanvas", "re-initialising Piano");
         this.piano = new Piano(screen_size_x, screen_size_y);
-        this.theme = Theme.fromPreferences(context);
+
+        String prefTheme = Preferences.selectedTheme(context);
+        this.theme = Theme.fromPreference(prefTheme);
 
         // for config trigger updates
         piano.addListener(appConfigTrigger);

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -146,18 +146,14 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
     private void drawBigKeys(Canvas canvas) {
         for (int i = 0; i < piano.get_keys_count(); i += 2) {
-            Paint paint = new Paint();
-            paint.setColor(theme.getColorForKey(i, piano.is_key_pressed(i)));
-            draw_key(canvas, piano.get_area_for_key(i), paint);
+            draw_key(canvas, piano.get_area_for_key(i), i);
         }
     }
 
     private void drawSmallKeys(Canvas canvas) {
         for (int i = 1; i < piano.get_keys_count(); i += 2) {
-            Paint paint = new Paint();
-            paint.setColor(piano.is_key_pressed(i) ? Color.GRAY : 0xFF333333);
             if (piano.get_area_for_flat_key(i) != Key.CANT_TOUCH_THIS) {
-                draw_key(canvas, piano.get_area_for_flat_key(i), paint);
+                draw_key(canvas, piano.get_area_for_flat_key(i), i);
             }
         }
     }
@@ -177,7 +173,10 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         draw_icon_on_black_key(androidCanvas, gearIcon, appConfigTrigger.getNextExpectedKey(), normalSize, normalSize);
     }
 
-    void draw_key(final Canvas canvas, final Key rect, final Paint p) {
+    void draw_key(final Canvas canvas, final Key rect, int i) {
+        Paint p = new Paint();
+        p.setColor(theme.getColorForKey(i, piano.is_key_pressed(i)));
+
         // Draw the main (solid) background of the key.
 
         Rect r = new Rect();

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -156,7 +156,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         for (int i = 1; i < piano.get_keys_count(); i += 2) {
             Paint paint = new Paint();
             paint.setColor(piano.is_key_pressed(i) ? Color.GRAY : 0xFF333333);
-            if (piano.get_area_for_flat_key(i) != null) {
+            if (piano.get_area_for_flat_key(i) != Key.CANT_TOUCH_THIS) {
                 draw_key(canvas, piano.get_area_for_flat_key(i), paint);
             }
         }

--- a/app/src/main/java/com/nicobrailo/pianoli/Preferences.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Preferences.java
@@ -20,7 +20,7 @@ public class Preferences {
     private final static String PREF_SELECTED_SOUND_SET = "selectedSoundSet";
     private final static String PREF_SELECTED_MELODIES = "selectedMelodies";
     private final static String PREF_ENABLE_MELODIES = "enableMelodies";
-    private static final String DEFAULT_THEME = "rainbow";
+    public static final String DEFAULT_THEME = "rainbow";
     private final static String PREF_THEME = "theme";
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -57,6 +57,12 @@ public enum Theme {
     private final KeyColor[] colors;
 
     public static Theme fromPreference(String selectedTheme) {
+        // defensive programming: if we ever mess up our preferences handling, it's better to fall back to default,
+        // than to crash the app.
+        if (selectedTheme == null) {
+            return RAINBOW;
+        }
+
         switch (selectedTheme) {
             case "black_and_white":
                 return BLACK_AND_WHITE;

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -8,6 +8,9 @@ import androidx.core.graphics.ColorUtils;
 public class Theme {
     public static final String PREFIX = "theme_";
 
+    /**
+     * The sequence of colors to render; repeats from the start if there are more keys than array entries.
+     */
     private final KeyColor[] colors;
 
     public static Theme fromPreferences(Context context) {
@@ -84,13 +87,32 @@ public class Theme {
     }
 
     public int getColorForKey(int keyIndex, boolean isPressed) {
-        final int col_idx = (keyIndex / 2) % colors.length;
+        final int col_idx = (keyIndex / 2) % colors.length; // divide by two to skip 'flat'/black keys at odd positions.
         final KeyColor color = colors[col_idx];
         return isPressed ? color.pressed : color.normal;
     }
 
+    /**
+     * The render-colours for a big piano key: {@link #normal} and {@link #pressed}.
+     *
+     * <p>
+     * Note that this only applies to big keys, the 'flat' keys are always black.
+     * </p>
+     */
     private static class KeyColor {
+        /** The normal rendering color, when the key is inactive */
         public final int normal;
+
+        /**
+         * The pressed/touched color of a key.
+         *
+         * <p>
+         * Not automatically derived from {@link #normal}, because different hues need different amounts of
+         * real lightening for the same amount of subjective lightening.
+         * </p>
+         *
+         * @see #createLighterWhenPressed(int, float)
+         */
         public final int pressed;
 
         public KeyColor(int normal, int pressed) {
@@ -102,5 +124,4 @@ public class Theme {
             return new KeyColor(color, ColorUtils.blendARGB(color, Color.WHITE, blendWhiteFactor));
         }
     }
-
 }

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -5,7 +5,51 @@ import android.graphics.Color;
 
 import androidx.core.graphics.ColorUtils;
 
-public class Theme {
+public enum Theme {
+    /**
+     * Note that light green, orange and yellow have higher lightness than other colors,
+     * so adding just a little white doesn't have the desired effect.
+     * That is why they have a larger proportion of white added in.
+     */
+    BOOMWHACKER(new KeyColor[] {
+        KeyColor.createLighterWhenPressed(Color.rgb(220, 0, 0), 0.5f),     // Red
+                KeyColor.createLighterWhenPressed(Color.rgb(255, 135, 0), 0.6f),   // Orange
+                KeyColor.createLighterWhenPressed(Color.rgb(255, 255, 0), 0.75f),   // Yellow
+                KeyColor.createLighterWhenPressed(Color.rgb(80, 220, 20), 0.6f),   // Light Green
+                KeyColor.createLighterWhenPressed(Color.rgb(0, 150, 150), 0.5f),   // Dark Green
+                KeyColor.createLighterWhenPressed(Color.rgb(95, 70, 165), 0.5f),   // Purple
+                KeyColor.createLighterWhenPressed(Color.rgb(213, 43, 149), 0.5f),  // Pink
+    }),
+
+    PASTEL(new KeyColor[] {
+        // https://colorbrewer2.org/#type=qualitative&scheme=Pastel1&n=8
+        KeyColor.createLighterWhenPressed(0xfffbb4ae, 0.5f),
+                KeyColor.createLighterWhenPressed(0xffb3cde3, 0.5f),
+                KeyColor.createLighterWhenPressed(0xffccebc5, 0.5f),
+                KeyColor.createLighterWhenPressed(0xffdecbe4, 0.5f),
+                KeyColor.createLighterWhenPressed(0xfffed9a6, 0.5f),
+                KeyColor.createLighterWhenPressed(0xffffffcc, 0.5f),
+                KeyColor.createLighterWhenPressed(0xffe5d8bd, 0.5f),
+    }),
+
+    RAINBOW(new KeyColor[] {
+        KeyColor.createLighterWhenPressed(0xff001caf, 0.5f), // darkblue
+                KeyColor.createLighterWhenPressed(0xff0099ff, 0.5f), // lightblue
+                KeyColor.createLighterWhenPressed(0xff63c624, 0.5f), // darkgreen
+                KeyColor.createLighterWhenPressed(0xffbde53d, 0.5f), // lightgreen
+                KeyColor.createLighterWhenPressed(0xfffcc000, 0.5f), // yellow
+                KeyColor.createLighterWhenPressed(0xffff810a, 0.5f), // lightorange
+                KeyColor.createLighterWhenPressed(0xffff5616, 0.5f), // darkorange
+                KeyColor.createLighterWhenPressed(0xffd51016, 0.5f), // red
+    }),
+
+    BLACK_AND_WHITE(new KeyColor[] {
+        new KeyColor(
+                Color.rgb(240, 240, 240),
+                Color.rgb(200, 200, 200)
+        )
+    });
+
     public static final String PREFIX = "theme_";
 
     /**
@@ -30,59 +74,9 @@ public class Theme {
         }
     }
 
-    /**
-     * Note that light green, orange and yellow have higher lightness than other colors,
-     * so adding just a little white doesn't have the desired effect.
-     * That is why they have a larger proportion of white added in.
-     */
-    private static final Theme BOOMWHACKER = new Theme(
-            new KeyColor[] {
-                    KeyColor.createLighterWhenPressed(Color.rgb(220, 0, 0), 0.5f),     // Red
-                    KeyColor.createLighterWhenPressed(Color.rgb(255, 135, 0), 0.6f),   // Orange
-                    KeyColor.createLighterWhenPressed(Color.rgb(255, 255, 0), 0.75f),   // Yellow
-                    KeyColor.createLighterWhenPressed(Color.rgb(80, 220, 20), 0.6f),   // Light Green
-                    KeyColor.createLighterWhenPressed(Color.rgb(0, 150, 150), 0.5f),   // Dark Green
-                    KeyColor.createLighterWhenPressed(Color.rgb(95, 70, 165), 0.5f),   // Purple
-                    KeyColor.createLighterWhenPressed(Color.rgb(213, 43, 149), 0.5f),  // Pink
-            }
-    );
 
-    private static final Theme PASTEL = new Theme(
-            new KeyColor[] {
-                    // https://colorbrewer2.org/#type=qualitative&scheme=Pastel1&n=8
-                    KeyColor.createLighterWhenPressed(0xfffbb4ae, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xffb3cde3, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xffccebc5, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xffdecbe4, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xfffed9a6, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xffffffcc, 0.5f),
-                    KeyColor.createLighterWhenPressed(0xffe5d8bd, 0.5f),
-            }
-    );
 
-    private static final Theme RAINBOW = new Theme(
-            new KeyColor[] {
-                    KeyColor.createLighterWhenPressed(0xff001caf, 0.5f), // darkblue
-                    KeyColor.createLighterWhenPressed(0xff0099ff, 0.5f), // lightblue
-                    KeyColor.createLighterWhenPressed(0xff63c624, 0.5f), // darkgreen
-                    KeyColor.createLighterWhenPressed(0xffbde53d, 0.5f), // lightgreen
-                    KeyColor.createLighterWhenPressed(0xfffcc000, 0.5f), // yellow
-                    KeyColor.createLighterWhenPressed(0xffff810a, 0.5f), // lightorange
-                    KeyColor.createLighterWhenPressed(0xffff5616, 0.5f), // darkorange
-                    KeyColor.createLighterWhenPressed(0xffd51016, 0.5f), // red
-            }
-    );
-
-    private static final Theme BLACK_AND_WHITE = new Theme(
-            new KeyColor[] {
-                    new KeyColor(
-                            Color.rgb(240, 240, 240),
-                            Color.rgb(200, 200, 200)
-                    )
-            }
-    );
-
-    private Theme(KeyColor[] colors) {
+    Theme(KeyColor[] colors) {
         this.colors = colors;
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -1,14 +1,36 @@
 package com.nicobrailo.pianoli;
 
 import android.graphics.Color;
-
 import androidx.core.graphics.ColorUtils;
 
+
+/**
+ * Switchable key-colouring decisions for {@link PianoCanvas}.
+ *
+ * <p>
+ * Whenever {@link PianoCanvas} renders a key, it asks the current <code>Theme</code>-variant for the paint colour.
+ * This allows us to switch palettes via preferences.
+ * </p>
+ *
+ * @see Preferences#selectedTheme(android.content.Context)
+ * @see PianoCanvas#drawKey(android.graphics.Canvas, int)
+ */
 public enum Theme {
     /**
+     * Boomwhackers are colour-coded pipes that produce a (tuned) note when hit.
+     * Their popularity in educational circles cemented their colour-to-note mapping as a de-facto international standard.
+     *
+     * <p>
+     * See also: <a href="https://en.wikipedia.org/wiki/Boomwhacker">wikipedia: Boomwhacker</a>, and
+     * <a href="https://boomwhackers.com/">boomwhackers.com</a>.
+     * </p>
+     *
+     *
+     * <p>
      * Note that light green, orange and yellow have higher lightness than other colors,
      * so adding just a little white doesn't have the desired effect.
      * That is why they have a larger proportion of white added in.
+     * </p>
      */
     BOOMWHACKER(new KeyColor[] {
         KeyColor.createLighterWhenPressed(Color.rgb(220, 0, 0), 0.5f),     // Red
@@ -20,17 +42,22 @@ public enum Theme {
                 KeyColor.createLighterWhenPressed(Color.rgb(213, 43, 149), 0.5f),  // Pink
     }),
 
+    /**
+     * Soft pastel tones, derived from <a href="https://colorbrewer2.org/#type=qualitative&scheme=Pastel1&n=8">Colorbrewer2.org: Pastel</a>.
+     */
     PASTEL(new KeyColor[] {
-        // https://colorbrewer2.org/#type=qualitative&scheme=Pastel1&n=8
-        KeyColor.createLighterWhenPressed(0xfffbb4ae, 0.5f),
-                KeyColor.createLighterWhenPressed(0xffb3cde3, 0.5f),
-                KeyColor.createLighterWhenPressed(0xffccebc5, 0.5f),
-                KeyColor.createLighterWhenPressed(0xffdecbe4, 0.5f),
-                KeyColor.createLighterWhenPressed(0xfffed9a6, 0.5f),
-                KeyColor.createLighterWhenPressed(0xffffffcc, 0.5f),
-                KeyColor.createLighterWhenPressed(0xffe5d8bd, 0.5f),
+        KeyColor.createLighterWhenPressed(0xfffbb4ae, 0.5f), // dark pink
+                KeyColor.createLighterWhenPressed(0xffb3cde3, 0.5f), // powder blue
+                KeyColor.createLighterWhenPressed(0xffccebc5, 0.5f), // pistachio green
+                KeyColor.createLighterWhenPressed(0xffdecbe4, 0.5f), // lavender
+                KeyColor.createLighterWhenPressed(0xfffed9a6, 0.5f), // orange
+                KeyColor.createLighterWhenPressed(0xffffffcc, 0.5f), // pale yellow
+                KeyColor.createLighterWhenPressed(0xffe5d8bd, 0.5f), // light pink
     }),
 
+    /**
+     * All the colours of the rainbow, C1 dark blue, C2 red, then looping back to blue.
+     */
     RAINBOW(new KeyColor[] {
         KeyColor.createLighterWhenPressed(0xff001caf, 0.5f), // darkblue
                 KeyColor.createLighterWhenPressed(0xff0099ff, 0.5f), // lightblue
@@ -42,13 +69,23 @@ public enum Theme {
                 KeyColor.createLighterWhenPressed(0xffd51016, 0.5f), // red
     }),
 
+    /**
+     * "classic" Ivory and Black.
+     */
     BLACK_AND_WHITE(new KeyColor[] {
-        new KeyColor(
-                Color.rgb(240, 240, 240),
-                Color.rgb(200, 200, 200)
+        new KeyColor( // white, lighter
+                Color.rgb(240, 240, 240), // normal: slightly muted white;
+                Color.rgb(200, 200, 200)  // darker gray when pressed
         )
-    });
+    }); // note that the black flat keys are implicit and hardcoded for all themes at the moment.
 
+    /**
+     * Prefix for preferences-values and translation strings.
+     *
+     * <p>
+     * Often used implicitly, so don't forget to do full-text searches across the project when changing this.
+     * </p>
+     */
     public static final String PREFIX = "theme_";
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -85,6 +85,10 @@ public enum Theme {
     }
 
     public int getColorForKey(int keyIndex, boolean isPressed) {
+        if ((keyIndex & 1) == 1) { // odd index = black/flat/small key
+            return isPressed ? Color.GRAY : 0xFF333333; // hardcoded "black" for now, but theme-able in the future.
+        }
+
         final int col_idx = (keyIndex / 2) % colors.length; // divide by two to skip 'flat'/black keys at odd positions.
         final KeyColor color = colors[col_idx];
         return isPressed ? color.pressed : color.normal;

--- a/app/src/main/java/com/nicobrailo/pianoli/Theme.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Theme.java
@@ -1,6 +1,5 @@
 package com.nicobrailo.pianoli;
 
-import android.content.Context;
 import android.graphics.Color;
 
 import androidx.core.graphics.ColorUtils;
@@ -57,8 +56,7 @@ public enum Theme {
      */
     private final KeyColor[] colors;
 
-    public static Theme fromPreferences(Context context) {
-        String selectedTheme = Preferences.selectedTheme(context);
+    public static Theme fromPreference(String selectedTheme) {
         switch (selectedTheme) {
             case "black_and_white":
                 return BLACK_AND_WHITE;

--- a/app/src/test/java/android/graphics/Color.java
+++ b/app/src/test/java/android/graphics/Color.java
@@ -1,0 +1,60 @@
+package android.graphics;
+
+/**
+ * Minimal test double for colour handling, so we can classload the {@link com.nicobrailo.pianoli.Theme} enum.
+ *
+ * <p>
+ * When test-compiling, this will shadow the default (not-mocked-exception-throwing) implementation
+ * provided by the Android Gradle Plugin.<br>
+ * This is a low-tech way of avoiding a full-featured mocking dependency like Powermock or Mockito.
+ * </p>
+ */
+public class Color {
+    /**
+     * Needed for {@link com.nicobrailo.pianoli.Theme#BLACK_AND_WHITE}
+     * @noinspection unused
+     */
+    public static int rgb(int red, int green, int blue) {
+        return 0;
+    }
+
+    /**
+     * Used internally in {@link androidx.core.graphics.ColorUtils}, which is used by {@link com.nicobrailo.pianoli.Theme.KeyColor#createLighterWhenPressed(int, float)}
+     * @noinspection unused
+     */
+    public static int alpha(int a) {
+        return 0;
+    }
+
+    /**
+     * Used internally in {@link androidx.core.graphics.ColorUtils}, which is used by {@link com.nicobrailo.pianoli.Theme.KeyColor#createLighterWhenPressed(int, float)}
+     * @noinspection unused
+     */
+    public static int red(int a) {
+        return 0;
+    }
+
+    /**
+     * Used internally in {@link androidx.core.graphics.ColorUtils}, which is used by {@link com.nicobrailo.pianoli.Theme.KeyColor#createLighterWhenPressed(int, float)}
+     * @noinspection unused
+     */
+    public static int green(int a) {
+        return 0;
+    }
+
+    /**
+     * Used internally in {@link androidx.core.graphics.ColorUtils}, which is used by {@link com.nicobrailo.pianoli.Theme.KeyColor#createLighterWhenPressed(int, float)}
+     * @noinspection unused
+     */
+    public static int blue(int a) {
+        return 0;
+    }
+
+    /**
+     * Used internally in {@link androidx.core.graphics.ColorUtils}, which is used by {@link com.nicobrailo.pianoli.Theme.KeyColor#createLighterWhenPressed(int, float)}
+     * @noinspection unused
+     */
+    public static int argb(int a, int r, int g, int b) {
+        return 0;
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -213,11 +212,8 @@ public class DynamicTranslationIdentifierTest {
      * @see Theme
      */
     public static List<String> getThemes() {
-        Field[] fields = Theme.class.getDeclaredFields();
-        return Arrays.stream(fields)
-                .filter(field -> Theme.class.equals(field.getType()))
-                .filter(field -> Modifier.isStatic(field.getModifiers()))
-                .map(Field::getName)
+        return Arrays.stream(Theme.values())
+                .map(Enum::name)
                 .collect(Collectors.toList());
     }
 

--- a/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/DynamicTranslationIdentifierTest.java
@@ -90,7 +90,7 @@ public class DynamicTranslationIdentifierTest {
      *
      * @see Theme
      * @see Theme#PREFIX
-     * @see Theme#fromPreferences(Context)
+     * @see Theme#fromPreference(String) 
      * @see Preferences#selectedTheme(Context)
      * @see R.xml#root_preferences
      */

--- a/app/src/test/java/com/nicobrailo/pianoli/PreferencesTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/PreferencesTest.java
@@ -1,0 +1,12 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PreferencesTest {
+    @Test
+    public void defaultThemeExists() {
+        assertEquals(Theme.RAINBOW, Theme.fromPreference(Preferences.DEFAULT_THEME));
+    }
+}

--- a/app/src/test/java/com/nicobrailo/pianoli/ThemeTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/ThemeTest.java
@@ -1,0 +1,69 @@
+package com.nicobrailo.pianoli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ThemeTest {
+    /**
+     * Checks if theme values from historical versions of the app can be decoded.
+     *
+     * <p>
+     * Tests against a hardcoded copy of {@link R.array#theme_entryValues}, in order to preserve historical values,
+     * even if we remove some themes in the future.
+     * </p>
+     *
+     * @see Theme#fromPreference(String)
+     * @see R.array#theme_entryValues
+     */
+    @ParameterizedTest(name = "[{index}] pref {0} -> Theme.{1}")
+    @CsvSource({
+            "rainbow,RAINBOW",
+            "pastel,PASTEL",
+            "black_and_white,BLACK_AND_WHITE",
+            "boomwhacker,BOOMWHACKER",
+    })
+    public void possiblyPersistedThemePreferencesWork(String persistedName, String expectedTheme) {
+        // test the intended, productive mapping
+        Theme decodedPref = Theme.fromPreference(persistedName);
+        assertEquals(expectedTheme, decodedPref.name(),
+                "mapping the possibly-persisted theme-preference '" + persistedName + "' yielded a surprising Theme-implementation: " + decodedPref);
+    }
+
+    /**
+     * Checks if all currently implemented {@link Theme}s can be reached via their preference-identifier.
+     *
+     * <p>
+     * This explicitly <em>does not</em> test if the app-UI will actually offer the theme in the settings UI.
+     * That kind of android UI-dependant test is out of scope here.
+     * </p>
+     *
+     * @see Theme#fromPreference(String)
+     */
+    @ParameterizedTest
+    @EnumSource(Theme.class)
+    public void fromPreferenceRoundTrip(Theme theme) {
+        String prefName = theme.name().toLowerCase(Locale.ROOT); // Root-locale should be sufficient for java identifiers.
+
+        assertEquals(theme, Theme.fromPreference(prefName),
+                "Theme not roundtrippable via preferences; see Theme.fromPreference()");
+    }
+
+    /**
+     * In case we ever mess up our preferences-handling, it is better to forget the user's color preference,
+     * than it is to crash the app.
+     */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = "non-existing-test-theme")
+    public void unknownPreferencesShouldFallback(String brokenPref) {
+        assertEquals(Theme.RAINBOW, Theme.fromPreference(brokenPref));
+    }
+}


### PR DESCRIPTION
Per discussion in #88 , I think I can make at least the `Theme` reflection there cleaner by making it an Enum instead of a class with static self-constants.  
That can be done as a separate change, which is this PR. If this is acceptable, I'll rebase #88 onto this after it's merged.

While Enum-ifying Theme, I noticed that it's a bit inconsistent that only *big* keys are theme-able.  
Pulling the color-decision for the small/flat keys into Theme as well allows some unification of drawing logic in `PianoCanvas`.  
Right now, flat keys are still hardcoded black, but this improvement means that if we ever want to make colorful flat keys, we need to adapt *only* `Theme`, which satisfies the Single-Responsibility-Principle.

The drawing-simplifications are further aided by making more of the "big vs small key area" logic internally handled in `Piano`.  
Ideally the property that "odd keyIdx == small key" should be a completely invisible implementation detail of `Piano`.  
I'm close to that goal, but not all the way there.

----

One thing I *don't* like about this MR is that we now need a mock for `android.graphics.Color`, since the enum-constants for `Theme` are now evaluated at static-initialiser time. Previously, since we didn't actually *use* the colors, we didn't run into this, as the classloader doesn´t load static fields until somebody accesses the first one (and then it loads *all* static fields in that class).  
For the moment, I've gone the simple-but-boilerplate-y route that I previously took for `Log`: provide a stub test-double that shadows the android-class, only during tests.  
I guess this is an example of why one should normally have wrappers and adapter-classes to isolate ones business logic from such "external" library stuff.  
Please let me know how much this bugs you; the alternative would be code `Theme` against a `com.nicobrailo.pianoli.Color`, and only convert to `android.graphics.Color`s once we get to drawing in `PianoCanvas`.