### PR TITLE
Notemapper completeness: equivalents around skipped flat-keys, and ♯-support

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/melodies/NoteMapper.java
@@ -20,6 +20,15 @@ public class NoteMapper {
             note = note+"1";
         }
 
+        // simplify fancy modifiers, to reduce switch-case boilerplate.
+        note = note
+                .replace('♭', 'b')
+                .replace('♯', '#');
+
+        // Convert note notation to key-index.
+        // This is *almost* regular enough to be a simple int-mapping function, but modifiers around the missing
+        // small keys jump by 2, instead of the normal 1; a direct int-calculation would need special-casing for those
+        // few jumps, making it less readable than this alternative (in this authors' opinion)
         switch (note) {
             // Octave 1
             case "B#0": // special, below our first supported octave, but the modifier bumps it up.
@@ -27,40 +36,33 @@ public class NoteMapper {
                 return 0;
             case "C#1":
             case "Db1":
-            case "D♭1":
                 return 1;
             case "D1":
                 return 2;
             case "D#1":
             case "Eb1":
-            case "E♭1":
                 return 3;
             case "E1":
             case "Fb1":
-            case "F♭1":
                 return 4;
             case "E#1":
             case "F1":
                 return 6;
             case "F#1":
             case "Gb1":
-            case "G♭1":
                 return 7;
             case "G1":
                 return 8;
             case "G#1":
             case "Ab1":
-            case "A♭1":
                 return 9;
             case "A1":
                 return 10;
             case "A#1":
             case "Bb1":
-            case "B♭1":
                 return 11;
             case "B1":
             case "Cb2":
-            case "C♭2":
                 return 12;
 
             // Octave 2
@@ -69,40 +71,33 @@ public class NoteMapper {
                 return 14;
             case "C#2":
             case "Db2":
-            case "D♭2":
                 return 15;
             case "D2":
                 return 16;
             case "D#2":
             case "Eb2":
-            case "E♭2":
                 return 17;
             case "E2":
             case "Fb2":
-            case "F♭2":
                 return 18;
             case "E#2":
             case "F2":
                 return 20;
             case "F#2":
             case "Gb2":
-            case "G♭2":
                 return 21;
             case "G2":
                 return 22;
             case "G#2":
             case "Ab2":
-            case "A♭2":
                 return 23;
             case "A2":
                 return 24;
             case "A#2":
             case "Bb2":
-            case "B♭2":
                 return 25;
             case "B2":
             case "Cb3": // special, beyond our first supported octave, but the modifier brings it down.
-            case "C♭3": // special, beyond our first supported octave, but the modifier brings it down.
                 return 26;
 
             default:

--- a/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/melodies/NoteMapperTest.java
@@ -2,13 +2,11 @@ package com.nicobrailo.pianoli.melodies;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.nicobrailo.pianoli.melodies.NoteMapper.NO_NOTE;
 import static com.nicobrailo.pianoli.melodies.NoteMapper.get_key_idx_from_note;
@@ -99,10 +97,25 @@ class NoteMapperTest {
         assertNotEquals(NO_NOTE, idx);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"C#1", "Db1", "D♭1"})
-    public void fancySynonyms(String note) {
-        assertEquals(1, get_key_idx_from_note(note),
+    /**
+     * Derives fancy ♭/♯ versions of modified notes from {@link #allNotesSource()}.
+     */
+    static List<Arguments> allSynonymsSource() {
+        return allNotesSource().stream()
+                .filter(note -> note.contains("#") || note.contains("b")) // keep only notes with (non-fancy) modifiers
+                .map(note -> Arguments.of(
+                        note,
+                        note
+                                .replace('b', '♭')
+                                .replace('#', '♯')
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @ParameterizedTest(name = "[{index}] {0} == {1}")
+    @MethodSource("allSynonymsSource")
+    public void fancySynonyms(String drabNote, String fancyNote) {
+        assertEquals(get_key_idx_from_note(drabNote), get_key_idx_from_note(fancyNote),
                 "all synonyms for the same note should work, including fancy symbols");
     }
 


### PR DESCRIPTION
I have recently been reading architecture articles on *not* striving for 100% code coverage.  
I found this very enlightening, as it's the opposite to what I've been doing so far.

The articles posit that 100% coverage as a blind goal leads to very brittle tests, needless busywork when refactoring codes (due to overfitted test-cases), and in general is a dogma that should not be blindly followed.
Instead, the articles advise to use coverage-gaps to *guide deeper analysis of the productive code*, looking for holes that bugs could theoretically hide in.

I revisited my (spotty) `NoteMapperTest` while attempting to keep this mindset.  
At the same time, reading about fuzz-testing inspired me to do an unbiased "all possible notes" test, which indeed uncovered gaps.

Ironically, I did end up with 100% line coverage :stuck_out_tongue_closed_eyes: 
(Though my branch-coverage is stuck at 75%, and I can't seem to figure out why)

P.S. The articles, in case others feel inspired.
- Programming is Terrible blog: [Write code that is easy to delete, not easy to extend.](https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to)
- [Martin Fowler on Test Coverage](https://martinfowler.com/bliki/TestCoverage.html)
- [Developer Testing: How much test coverage do you need? - The Testivus Answer](https://www.developertesting.com/archives/month200705/20070504-000425.html)
- [Artima: the way of Testivus](https://www.artima.com/weblogs/viewpost.jsp?thread=203994)

---

As for release-cutting: since this has zero user-visible benefit, I wouldn't mind if this is not included in the release for the Brother-John-Song (#88, #89), so please don't consider this urgent.