### PR TITLE
Wait for 300ms after correct unlock combination to actually unlock

### DIFF
--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -50,6 +50,12 @@ abstract class AppConfigTrigger implements PianoListener {
     private final Set<Integer> pressedConfigKeys = new HashSet<>();
 
     /**
+     * The total amount of currently pressed keys.
+     * We do not allow the unlock sequence to start if there are any other pressed keys.
+     */
+    private int pressedKeyCount = 0;
+
+    /**
      * User frustration tracker: how badly are they failing to open the config?
      *
      * @see #cb
@@ -174,7 +180,15 @@ abstract class AppConfigTrigger implements PianoListener {
 
     @Override
     public void onKeyDown(int keyIdx) {
-        if (keyIdx == nextExpectedKey && pendingTimerID == NO_TIMER_ID) {
+        boolean validSequence = keyIdx == nextExpectedKey && pendingTimerID == NO_TIMER_ID;
+        if (validSequence && pressedConfigKeys.isEmpty() && pressedKeyCount != 0) {
+            // If this is the first key of the sequence, but there are already some pressed keys,
+            // do not start the sequence.
+            validSequence = false;
+        }
+
+        pressedKeyCount++;
+        if (validSequence) {
             // track user's progress in the unlock-sequence
             pressedConfigKeys.add(keyIdx);
             if (pressedConfigKeys.size() == CONFIG_TRIGGER_COUNT) {
@@ -206,12 +220,23 @@ abstract class AppConfigTrigger implements PianoListener {
      */
     @Override
     public void onKeyUp(int keyIdx) {
+        pressedKeyCount--;
+
         if (pressedConfigKeys.contains(keyIdx)) {
             // The released key was part of an in-progress unlock-sequence
             // (completed sequence would have invoked reset, thus clearing this set, before we get here)
             tooltipReminder.registerFailedAttempt();
         }
         reset();
+    }
+
+    /**
+     * Reset the pressed key count.
+     * This is done to protect us should the user somehow manage to create unbalanced key-down/up
+     * calls. In that case it would not be possible to unlock the config an the user would get stuck.
+     */
+    public void resetPressedKeys() {
+        pressedKeyCount = 0;
     }
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -28,7 +28,7 @@ abstract class AppConfigTrigger implements PianoListener {
     public static final int CONFIG_TRIGGER_COUNT = 2;
 
     /** For how many milliseconds must the trigger key combination be held to activate. */
-    public static final int TRIGGER_DELAY_MS = 500;
+    public static final int TRIGGER_DELAY_MS = 300;
 
     /**
      * Candidate keys to receive a gear icon.

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -230,12 +230,8 @@ abstract class AppConfigTrigger implements PianoListener {
         reset();
     }
 
-    /**
-     * Reset the pressed key count.
-     * This is done to protect us should the user somehow manage to create unbalanced key-down/up
-     * calls. In that case it would not be possible to unlock the config an the user would get stuck.
-     */
-    public void resetPressedKeys() {
+    @Override
+    public void onAllKeysUp() {
         pressedKeyCount = 0;
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/AppConfigTrigger.java
@@ -23,14 +23,17 @@ import java.util.Set;
  * brushing another key), but they <em>would</em> be able to trigger a serial sequence by playing "follow the gear".
  * </p>
  */
-class AppConfigTrigger implements PianoListener {
+abstract class AppConfigTrigger implements PianoListener {
     /** How many of the geared keys must be held before config opens */
     public static final int CONFIG_TRIGGER_COUNT = 2;
+
+    /** For how many milliseconds must the trigger key combination be held to activate. */
+    public static final int TRIGGER_DELAY_MS = 500;
 
     /**
      * Candidate keys to receive a gear icon.
      *
-     * <p>Currently a hardcoded set of the first </p>
+     * <p>Currently a hardcoded set of keys</p>
      */
     private static final Set<Integer> BLACK_KEYS = new HashSet<>(Arrays.asList(1, 3, 7, 9, 11, 15));
 
@@ -67,6 +70,19 @@ class AppConfigTrigger implements PianoListener {
      */
     private AppConfigCallback cb = null;
 
+    /**
+     * Represents an timer ID that does not exist.
+     */
+    private static final int NO_TIMER_ID = -1;
+
+    /**
+     * Which timer are we waiting for right now to open the config?
+     * This is set only when all trigger keys have been pressed and the timer has not fired yet.
+     * If a key is pressed or released while we are waiting for the timer to finish,
+     * this field will be reset and no config will open.
+     */
+    private int pendingTimerID = NO_TIMER_ID;
+
     AppConfigTrigger() {
         nextExpectedKey = calculateNextExpectedKey();
     }
@@ -93,7 +109,7 @@ class AppConfigTrigger implements PianoListener {
     }
 
     /**
-     * @return currently expected next key in the sequence (without changing it)
+     * @return currently expected next key in the sequence (without changing it). May be -1 if there is no expected key.
      * @see #calculateNextExpectedKey();
      */
     public int getNextExpectedKey() {
@@ -153,18 +169,18 @@ class AppConfigTrigger implements PianoListener {
         }
 
         pressedConfigKeys.clear();
+        pendingTimerID = NO_TIMER_ID;
     }
 
     @Override
     public void onKeyDown(int keyIdx) {
-        if (keyIdx == nextExpectedKey) {
+        if (keyIdx == nextExpectedKey && pendingTimerID == NO_TIMER_ID) {
             // track user's progress in the unlock-sequence
             pressedConfigKeys.add(keyIdx);
             if (pressedConfigKeys.size() == CONFIG_TRIGGER_COUNT) {
-                // Sequence complete!
-                reset(); // clear it so it's no longer counted as in-progress.
-                // Open Sesame!
-                cb.requestConfig();
+                nextExpectedKey = -1;
+                pendingTimerID = (int)(System.nanoTime() & 0x7FFF_FFFF);// Arbitrary positive semi-unique ID
+                scheduleTimer(TRIGGER_DELAY_MS, pendingTimerID);
             } else {
                 nextExpectedKey = calculateNextExpectedKey();
             }
@@ -196,6 +212,24 @@ class AppConfigTrigger implements PianoListener {
             tooltipReminder.registerFailedAttempt();
         }
         reset();
+    }
+
+    /**
+     * Requests that the implementation calls {@link #onTimer(int)}
+     * after some delay.
+     * @param delayMs how many milliseconds should the delay be
+     * @param timerID should be passed to {@link #onTimer(int)} as a parameter, to identify the timer
+     */
+    protected abstract void scheduleTimer(int delayMs, int timerID);
+
+    protected void onTimer(int timerID) {
+        if (timerID == pendingTimerID) {
+            pendingTimerID = NO_TIMER_ID;
+            // Sequence complete!
+            reset(); // clear it so it's no longer counted as in-progress.
+            // Open Sesame!
+            cb.requestConfig();
+        }
     }
 
     /**

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -82,10 +82,6 @@ public class Piano {
         return keys_count;
     }
 
-    void resetState() {
-        Arrays.fill(key_pressed, 0);
-    }
-
     boolean is_key_pressed(int key_idx) {
         if (isOutOfRange(key_idx)) {
             Log.d("PianOli::Piano", "This shouldn't happen: isKeyPressed out of range, key" + key_idx);
@@ -134,6 +130,16 @@ public class Piano {
             for (PianoListener l : listeners) {
                 l.onKeyUp(keyIdx);
             }
+        }
+    }
+
+    /**
+     * Call whenever you are sure that all keys should be up (not pressed).
+     */
+    public void doAllKeysUp() {
+        Arrays.fill(key_pressed, 0);
+        for (PianoListener l : listeners) {
+            l.onAllKeysUp();
         }
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -41,8 +41,8 @@ public class Piano {
     private final int keys_flats_height;
     private final int keys_count;
 
-    /** state tracker: which keys are <em>currently</em> pressed */
-    private final boolean[] key_pressed;
+    /** State tracker: which keys are <em>currently</em> pressed (and with how many fingers) */
+    private final int[] key_pressed;
 
     private final List<PianoListener> listeners;
 
@@ -66,7 +66,7 @@ public class Piano {
         // +1: not sure about this... The *2 already ensures a (partial) flat-key on the (partial) big-key.
         keys_count = (big_keys * 2) + 1;
 
-        key_pressed = new boolean[keys_count]; // new array defaults to all false;
+        key_pressed = new int[keys_count]; // new array defaults to all 0
         listeners = new ArrayList<>();
     }
 
@@ -83,7 +83,7 @@ public class Piano {
     }
 
     void resetState() {
-        Arrays.fill(key_pressed, false);
+        Arrays.fill(key_pressed, 0);
     }
 
     boolean is_key_pressed(int key_idx) {
@@ -92,7 +92,7 @@ public class Piano {
             return false;
         }
 
-        return key_pressed[key_idx];
+        return key_pressed[key_idx] > 0;
     }
 
     /**
@@ -106,9 +106,9 @@ public class Piano {
             return;
         }
 
-        if (!key_pressed[keyIdx]) {
+        key_pressed[keyIdx] += 1;
+        if (key_pressed[keyIdx] == 1) {
             Log.d("PianOli::Piano", "Key " + keyIdx + " is now DOWN");
-            key_pressed[keyIdx] = true;
 
             for (PianoListener l : listeners) {
                 l.onKeyDown(keyIdx);
@@ -127,9 +127,9 @@ public class Piano {
             return;
         }
 
-        if (key_pressed[keyIdx]) {
+        key_pressed[keyIdx] -= 1;
+        if (key_pressed[keyIdx] == 0) {
             Log.d("PianOli::Piano", "Key " + keyIdx + " is now UP");
-            key_pressed[keyIdx] = false;
 
             for (PianoListener l : listeners) {
                 l.onKeyUp(keyIdx);

--- a/app/src/main/java/com/nicobrailo/pianoli/Piano.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/Piano.java
@@ -106,11 +106,13 @@ public class Piano {
             return;
         }
 
-        Log.d("PianOli::Piano", "Key " + keyIdx + " is now DOWN");
-        key_pressed[keyIdx] = true;
+        if (!key_pressed[keyIdx]) {
+            Log.d("PianOli::Piano", "Key " + keyIdx + " is now DOWN");
+            key_pressed[keyIdx] = true;
 
-        for (PianoListener l : listeners) {
-            l.onKeyDown(keyIdx);
+            for (PianoListener l : listeners) {
+                l.onKeyDown(keyIdx);
+            }
         }
     }
 
@@ -125,11 +127,13 @@ public class Piano {
             return;
         }
 
-        Log.d("PianOli::Piano", "Key " + keyIdx + " is now UP");
-        key_pressed[keyIdx] = false;
+        if (key_pressed[keyIdx]) {
+            Log.d("PianOli::Piano", "Key " + keyIdx + " is now UP");
+            key_pressed[keyIdx] = false;
 
-        for (PianoListener l : listeners) {
-            l.onKeyUp(keyIdx);
+            for (PianoListener l : listeners) {
+                l.onKeyUp(keyIdx);
+            }
         }
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -109,7 +109,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
         // for config trigger updates
         piano.addListener(appConfigTrigger);
-        resetPianoState();
+        appConfigTrigger.reset();
 
         // to redraw on key-touches, must be after config handler to ensure its input is also drawn
         piano.addListener(this);
@@ -131,6 +131,8 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             soundMaker = new StraightKeySoundMaker(soundSet);
         }
         piano.addListener(soundMaker);
+
+        piano.doAllKeysUp();
         Log.i("PianOli::PianoCanvas", "re-initialising Piano - DONE");
     }
 
@@ -312,16 +314,10 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         redraw();
     }
 
-    /**
-     * Something has gone wrong with the piano or canvas state, and our state is out of sync
-     * with the real state of the world (e.g. somehow we missed a touch down or up event).
-     * Try to reset the state and hope the app survives.
-     */
-    void resetPianoState() {
+    // This is called though piano.doAllKeysUp().
+    @Override
+    public void onAllKeysUp() {
         touch_pointer_to_keys.clear();
-        appConfigTrigger.reset();
-        appConfigTrigger.resetPressedKeys();
-        piano.resetState();
     }
 
     @Override
@@ -344,7 +340,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             case MotionEvent.ACTION_POINTER_DOWN: {
                 if (touch_pointer_to_keys.containsKey(ptr_id)) {
                     Log.e("PianOli::DrawingCanvas", "Touch-track error: Repeated touch-down event received");
-                    resetPianoState();
+                    piano.doAllKeysUp();
                     return super.onTouchEvent(event);
                 }
 
@@ -366,7 +362,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
                     if (!touch_pointer_to_keys.containsKey(ptr_id)) {
                         Log.e("PianOli::DrawingCanvas", "Touch-track error: Missed touch-up event");
-                        resetPianoState();
+                        piano.doAllKeysUp();
                         return super.onTouchEvent(event);
                     }
                     // check if key changed
@@ -386,12 +382,22 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
             case MotionEvent.ACTION_UP: {
                 if (!touch_pointer_to_keys.containsKey(ptr_id)) {
                     Log.e("PianOli::DrawingCanvas", "Touch-track error: Repeated touch-up event received");
-                    resetPianoState();
+                    piano.doAllKeysUp();
                     return super.onTouchEvent(event);
                 }
 
                 touch_pointer_to_keys.remove(ptr_id);
                 piano.doKeyUp(key_idx);
+
+                // We are worried about missing touch events, since it would leave us in an invalid
+                // state. We assume, that getting MotionEvents may not be reliable,
+                // but that the information contained within these events is reliable.
+                // So if we detect that there are no touches on the screen right now,
+                // we call the onAllKeysUp signal (via piano) - it should not do anything,
+                // but it will fix our state if it is broken.
+                if (event.getPointerCount() <= 1) {
+                    piano.doAllKeysUp();
+                }
 
                 return true;
             }

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -51,7 +51,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
     private final Drawable gearIcon;
     private Theme theme;
 
-    private Map<Integer, Integer> touch_pointer_to_keys = new HashMap<>();
+    private final Map<Integer, Integer> touch_pointer_to_keys = new HashMap<>();
     private SoundSet soundSet;
 
     public PianoCanvas(Context context, AttributeSet as) {
@@ -79,7 +79,12 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         final String prefSoundset = Preferences.selectedSoundSet(context);
 
         // DANGER ZONE: !! delicate ordering dependencies in this block !!
-        appConfigTrigger = new AppConfigTrigger();
+        appConfigTrigger = new AppConfigTrigger() {
+            @Override
+            protected void scheduleTimer(int delayMs, int timerID) {
+                getHandler().postDelayed(() -> appConfigTrigger.onTimer(timerID), delayMs);
+            }
+        };
         // gotcha: gets just-created appConfigHandler via field
         reInitPiano(context, prefSoundset); // danger: impl leaks `this` pointer before ctor finished
         // gotcha: needs piano field that was just initialised by reInitPiano above
@@ -155,8 +160,11 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
         }
 
         // draw next expected key with large icon, for more user-attention.
-        int normalSize = (int) (piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
-        draw_icon_on_black_key(androidCanvas, gearIcon, appConfigTrigger.getNextExpectedKey(), normalSize, normalSize);
+        int key = appConfigTrigger.getNextExpectedKey();
+        if (key >= 0) {
+            int normalSize = (int) (piano.get_keys_flat_width() * CONFIG_ICON_SIZE_TO_FLAT_KEY_RATIO);
+            draw_icon_on_black_key(androidCanvas, gearIcon, key, normalSize, normalSize);
+        }
     }
 
     void drawKey(final Canvas canvas, final int i) {

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -109,7 +109,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
         // for config trigger updates
         piano.addListener(appConfigTrigger);
-        appConfigTrigger.resetPressedKeys();
+        resetPianoState();
 
         // to redraw on key-touches, must be after config handler to ensure its input is also drawn
         piano.addListener(this);
@@ -320,6 +320,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
     void resetPianoState() {
         touch_pointer_to_keys.clear();
         appConfigTrigger.reset();
+        appConfigTrigger.resetPressedKeys();
         piano.resetState();
     }
 

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoCanvas.java
@@ -109,6 +109,7 @@ class PianoCanvas extends SurfaceView implements SurfaceHolder.Callback, PianoLi
 
         // for config trigger updates
         piano.addListener(appConfigTrigger);
+        appConfigTrigger.resetPressedKeys();
 
         // to redraw on key-touches, must be after config handler to ensure its input is also drawn
         piano.addListener(this);

--- a/app/src/main/java/com/nicobrailo/pianoli/PianoListener.java
+++ b/app/src/main/java/com/nicobrailo/pianoli/PianoListener.java
@@ -10,7 +10,16 @@ public interface PianoListener {
     void onKeyDown(int keyIdx);
 
     /**
-     * signals key <code>keyIdx</code> has been released.
+     * Signals key <code>keyIdx</code> has been released.
      */
     void onKeyUp(int keyIdx);
+
+    /**
+     * Signals that all keys should be released right now.
+     * Called after the last onKeyUp.
+     * This method is used purely as a safeguard - it should not add any new information.
+     * But in case that there is a bug and the key down and up is unbalanced,
+     * this can be used to reset to a valid state.
+     */
+    default void onAllKeysUp() {}
 }

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -124,7 +124,8 @@ class AppConfigTriggerTest {
             assertEquals(0, spyCallback.triggerCount,
                     "even after a gazillion (i="+i+") bad attempts, we should never trigger");
             // Reset
-            trigger.resetPressedKeys();
+            trigger.reset();
+            trigger.onAllKeysUp();
         }
     }
 

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -9,23 +9,45 @@ class AppConfigTriggerTest {
     private SpyCallback spyCallback;
     private AppConfigTrigger trigger;
 
+    private boolean automaticTrigger = false;
+    private int scheduledTimerID = -1;
+
     @BeforeEach
     public void setup() {
         spyCallback = new SpyCallback();
-        trigger = new AppConfigTrigger();
+        trigger = new AppConfigTrigger() {
+            @Override
+            protected void scheduleTimer(int delayMs, int timerID) {
+                assertTrue(delayMs >= 0, "delay should not be negative");
+                assertTrue(timerID >= 0, "timer ID must be positive");
+                if (automaticTrigger) {
+                    onTimer(timerID);
+                } else {
+                    scheduledTimerID = timerID;
+                }
+            }
+        };
         trigger.setConfigRequestCallback(spyCallback);
     }
 
     @Test
     public void happyPathWorks() {
+        automaticTrigger = false;
         for (int i = 0; i < AppConfigTrigger.CONFIG_TRIGGER_COUNT; i++) {
             assertEquals(0, spyCallback.triggerCount,
                     "Before reaching trigger limit, we should not yet trigger (i=" + i + ")");
             int nextExpectedKey = trigger.getNextExpectedKey();
             trigger.onKeyDown(nextExpectedKey);
         }
+        assertEquals(0, spyCallback.triggerCount, "should not trigger yet");
+        assertEquals(-1, trigger.getNextExpectedKey(), "while waiting for the timer, there should be no expected key to press");
+        assertEquals(2, trigger.getPressedConfigKeys().size(), "while waiting for the timer, the pressed key should still be pressed");
+        assertNotEquals(-1, scheduledTimerID, "there should be a timer scheduled");
+
+        trigger.onTimer(scheduledTimerID);
+
         assertEquals(1, spyCallback.triggerCount,
-                "after hitting the required amount of trigger keys, without mistakes, config should trigger.");
+                "after hitting the required amount of trigger keys, without mistakes and after waiting for timer, config should trigger.");
 
         assertTrue(trigger.getPressedConfigKeys().isEmpty(),
                 "unlock should clear the pressed-state for the successful sequence.\n" +
@@ -35,7 +57,45 @@ class AppConfigTriggerTest {
     }
 
     @Test
+    public void timerCancelledOnKeyUp() {
+        automaticTrigger = false;
+        int lastKey = 0;
+        for (int i = 0; i < AppConfigTrigger.CONFIG_TRIGGER_COUNT; i++) {
+            assertEquals(0, spyCallback.triggerCount,
+                    "Before reaching trigger limit, we should not yet trigger (i=" + i + ")");
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+            lastKey = nextExpectedKey;
+        }
+
+        assertEquals(0, spyCallback.triggerCount);
+        trigger.onKeyUp(lastKey);
+        assertEquals(0, spyCallback.triggerCount);
+        trigger.onTimer(scheduledTimerID);
+        assertEquals(0, spyCallback.triggerCount);
+    }
+
+
+    @Test
+    public void timerCancelledOnKeyDown() {
+        automaticTrigger = false;
+        for (int i = 0; i < AppConfigTrigger.CONFIG_TRIGGER_COUNT; i++) {
+            assertEquals(0, spyCallback.triggerCount,
+                    "Before reaching trigger limit, we should not yet trigger (i=" + i + ")");
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+        }
+
+        assertEquals(0, spyCallback.triggerCount);
+        trigger.onKeyDown(2);// Not a black key, so it is not pressed down
+        assertEquals(0, spyCallback.triggerCount);
+        trigger.onTimer(scheduledTimerID);
+        assertEquals(0, spyCallback.triggerCount);
+    }
+
+    @Test
     public void badKeyDownShouldCancelProgress() {
+        automaticTrigger = true;
         for (int i = 0; i < 100; i++) {
             // make some correct progress
             int nextExpectedKey = trigger.getNextExpectedKey();
@@ -54,6 +114,7 @@ class AppConfigTriggerTest {
 
     @Test
     public void anyKeyUpShouldCancelProgress() {
+        automaticTrigger = true;
         for (int i = 0; i < 50; i++) { // try with a LOT of keys, including some absurdly high ones.
             // make some correct progress
             int nextExpectedKey = trigger.getNextExpectedKey();

--- a/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/AppConfigTriggerTest.java
@@ -94,6 +94,20 @@ class AppConfigTriggerTest {
     }
 
     @Test
+    public void noOtherKeysMustBePressedToUnlock() {
+        automaticTrigger = true;
+        trigger.onKeyDown(2);// Not a black key, so it is not pressed down
+
+        for (int i = 0; i < AppConfigTrigger.CONFIG_TRIGGER_COUNT; i++) {
+            assertEquals(0, spyCallback.triggerCount,
+                    "Before reaching trigger limit, we should not yet trigger (i=" + i + ")");
+            int nextExpectedKey = trigger.getNextExpectedKey();
+            trigger.onKeyDown(nextExpectedKey);
+        }
+        assertEquals(0, spyCallback.triggerCount, "should not trigger yet");
+    }
+
+    @Test
     public void badKeyDownShouldCancelProgress() {
         automaticTrigger = true;
         for (int i = 0; i < 100; i++) {
@@ -109,6 +123,8 @@ class AppConfigTriggerTest {
                     "a bad key-down should reset all progress");
             assertEquals(0, spyCallback.triggerCount,
                     "even after a gazillion (i="+i+") bad attempts, we should never trigger");
+            // Reset
+            trigger.resetPressedKeys();
         }
     }
 

--- a/app/src/test/java/com/nicobrailo/pianoli/PianoTest.java
+++ b/app/src/test/java/com/nicobrailo/pianoli/PianoTest.java
@@ -76,7 +76,7 @@ class PianoTest {
         piano.doKeyDown(i);
         assumeTrue(piano.is_key_pressed(i));
 
-        piano.resetState();
+        piano.doAllKeysUp();
 
         assertFalse(piano.is_key_pressed(i));
     }


### PR DESCRIPTION
Closes #12.

During playing we have somehow managed to unlock the app, so this is probably necessary.

The abstract method is probably not ideal, but it is the simplest testable way to do this without pointless ceremony.

I have also noticed, that it is possible to unlock the config when other keys are pressed at the start of the unlock sequence, so I have blocked that. As a side effect of this change, it is no longer possible to press a key twice, but at least the keys work more like a real piano keys.