### PR TITLE
Ci/bump action versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Build and test app
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   build-and-check:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,21 +11,21 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: set up JDK 17
-      uses: actions/setup-java@v3
+    - name: set up JDK 21
+      uses: actions/setup-java@v5
       with:
         # temurin LTS is pre-cached on runners
         # https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Hosted-Tool-Cache
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     # prevent supply chain attacks from replacing our gradle with malicious code
     # https://github.com/gradle/wrapper-validation-action#readme
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v6
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v6
       with:
         # configure gradle to track dependency info for GitHub Dependency Graph API
         # Submission is left to other job, due to (rightfully!) missing write permissions if branch is contributed
@@ -36,7 +36,7 @@ jobs:
       run: ./gradlew check --no-daemon
 
     - name: Archive build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: outputs
         path: app/build/outputs

--- a/.github/workflows/submit-dependency-snapshot.yml
+++ b/.github/workflows/submit-dependency-snapshot.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve dependency graph artifact and submit
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v6
         with:
           dependency-graph: download-and-submit


### PR DESCRIPTION
We were using V3, which is deprecated. Updating to updated actions. Also making actions trigger on any branch with '**' ('*' won't match branch names with a slash in it)
